### PR TITLE
Improve README with setup and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,3 +260,48 @@ Example manifests are provided in the `k8s` directory. After building and pushin
 kubectl apply -f k8s
 ```
 
+## API Documentation
+
+LinChat's FastAPI backend exposes an OpenAPI schema and interactive Swagger UI.
+Once the server is running, navigate to <http://localhost:8000/docs> to explore
+all available endpoints. The ReDoc view is available at
+<http://localhost:8000/redoc>. A copy of the generated schema is included in
+`docs/openapi.json` and can be regenerated with:
+
+```bash
+python scripts/generate_openapi.py
+```
+
+## Tutorials & Examples
+
+Below are a few example workflows to help you get started with common research
+tasks.
+
+### Summarize Documents
+
+1. Upload one or more files via `/upload` or the frontend.
+2. Call `/summarize` with a prompt like `"Summarize the key findings"` to receive
+   a structured summary with citations.
+
+### Generate Tables and Slides
+
+* Use `/generate_table` to request tabular data from the LLM, then `/export/excel`
+  to download the results as an Excel file.
+* Use `/generate_slides` to create a slide deck structure which can be exported
+  to PowerPoint via `/export/pptx`.
+
+### Custom Data Analysis
+
+Upload an Excel file and send a prompt to `/custom_analysis`. LinChat will
+generate and execute Rust code using Polars to return the requested analytics
+along with a chart in the response headers.
+
+### Running Tests
+
+The project includes a pytest suite. After installing the requirements, run:
+
+```bash
+pytest -q
+```
+
+

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,812 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/query": {
+      "post": {
+        "summary": "Query Llm",
+        "description": "Query OpenRouter LLM with context retrieval and optional web scraping.",
+        "operationId": "query_llm_query_post",
+        "parameters": [
+          {
+            "name": "prompt",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prompt"
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Url"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "name": "top_k",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 5,
+              "title": "Top K"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search": {
+      "get": {
+        "summary": "Search Docs",
+        "description": "Retrieve relevant document chunks from the vector DB.",
+        "operationId": "search_docs_search_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "top_k",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 5,
+              "title": "Top K"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/source/{req_id}/{cid}": {
+      "get": {
+        "summary": "Get Source",
+        "description": "Return the stored source excerpt for a citation ID.",
+        "operationId": "get_source_source__req_id___cid__get",
+        "parameters": [
+          {
+            "name": "req_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Req Id"
+            }
+          },
+          {
+            "name": "cid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/scrape": {
+      "post": {
+        "summary": "Scrape Endpoint",
+        "description": "Scrape a URL directly or via search.",
+        "operationId": "scrape_endpoint_internal_scrape_post",
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Url"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin": {
+      "get": {
+        "summary": "Admin Page",
+        "operationId": "admin_page_admin_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBasic": []
+          }
+        ]
+      }
+    },
+    "/admin/set_key": {
+      "post": {
+        "summary": "Set Key",
+        "operationId": "set_key_admin_set_key_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_set_key_admin_set_key_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBasic": []
+          }
+        ]
+      }
+    },
+    "/documents": {
+      "get": {
+        "summary": "Get Documents",
+        "operationId": "get_documents_documents_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/upload": {
+      "post": {
+        "summary": "Upload File",
+        "description": "Accept a file upload, store it, parse and persist chunks.",
+        "operationId": "upload_file_upload_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_file_upload_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/summarize": {
+      "post": {
+        "summary": "Summarize",
+        "description": "Return a structured summary for the prompt.",
+        "operationId": "summarize_summarize_post",
+        "parameters": [
+          {
+            "name": "prompt",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prompt"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/generate_table": {
+      "post": {
+        "summary": "Table",
+        "description": "Generate a table structure from the LLM.",
+        "operationId": "table_generate_table_post",
+        "parameters": [
+          {
+            "name": "prompt",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prompt"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/generate_slides": {
+      "post": {
+        "summary": "Slides",
+        "description": "Generate a slide deck structure from the LLM.",
+        "operationId": "slides_generate_slides_post",
+        "parameters": [
+          {
+            "name": "prompt",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prompt"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/custom_analysis": {
+      "post": {
+        "summary": "Custom Analysis",
+        "description": "Generate Rust code via the LLM for custom analysis and return results.",
+        "operationId": "custom_analysis_custom_analysis_post",
+        "parameters": [
+          {
+            "name": "prompt",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prompt"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_custom_analysis_custom_analysis_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/export/pdf": {
+      "post": {
+        "summary": "Export Pdf",
+        "description": "Convert provided content to PDF and return the file.",
+        "operationId": "export_pdf_export_pdf_post",
+        "parameters": [
+          {
+            "name": "content",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Content"
+            }
+          },
+          {
+            "name": "markdown",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Markdown"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/export/excel": {
+      "post": {
+        "summary": "Export Excel",
+        "description": "Export a table schema to an Excel file.",
+        "operationId": "export_excel_export_excel_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Table"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/export/pptx": {
+      "post": {
+        "summary": "Export Pptx",
+        "description": "Export slide deck JSON to a PPTX file.",
+        "operationId": "export_pptx_export_pptx_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SlideDeck"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Body_custom_analysis_custom_analysis_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_custom_analysis_custom_analysis_post"
+      },
+      "Body_set_key_admin_set_key_post": {
+        "properties": {
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "title": "Body_set_key_admin_set_key_post"
+      },
+      "Body_upload_file_upload_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          },
+          "shared": {
+            "type": "boolean",
+            "title": "Shared",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_file_upload_post"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Slide": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "bullets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Bullets",
+            "default": []
+          },
+          "table": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Table"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "Slide"
+      },
+      "SlideDeck": {
+        "properties": {
+          "slides": {
+            "items": {
+              "$ref": "#/components/schemas/Slide"
+            },
+            "type": "array",
+            "title": "Slides"
+          }
+        },
+        "type": "object",
+        "required": [
+          "slides"
+        ],
+        "title": "SlideDeck"
+      },
+      "Table": {
+        "properties": {
+          "columns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Columns"
+          },
+          "rows": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "columns",
+          "rows"
+        ],
+        "title": "Table"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBasic": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""Generate OpenAPI schema for LinChat."""
+import json
+import importlib
+import types
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+play_mod = types.ModuleType('playwright')
+fake_async = types.ModuleType('playwright.async_api')
+fake_async.async_playwright = lambda: None
+play_mod.async_api = fake_async
+sys.modules.setdefault('playwright', play_mod)
+sys.modules.setdefault('playwright.async_api', fake_async)
+sys.modules.setdefault('chromadb', types.SimpleNamespace(PersistentClient=object))
+sys.modules.setdefault('chromadb.config', types.SimpleNamespace(Settings=object))
+sys.modules.setdefault('sentence_transformers', types.SimpleNamespace(SentenceTransformer=lambda x: None))
+analysis_stub = types.ModuleType('analysis_agent')
+analysis_stub.run_custom_analysis = lambda *a, **k: {}
+sys.modules.setdefault('app.analysis_agent', analysis_stub)
+weasy = types.ModuleType('weasyprint')
+weasy.HTML = object
+sys.modules.setdefault('weasyprint', weasy)
+sys.modules.setdefault('markdown', types.ModuleType('markdown'))
+auth_stub = types.ModuleType('app.auth')
+class RouterStub:
+    def __init__(self):
+        self.routes = []
+        self.on_startup = []
+        self.on_shutdown = []
+        self.lifespan_context = None
+router = RouterStub()
+auth_stub.fastapi_users = types.SimpleNamespace(
+    get_auth_router=lambda *a, **k: router,
+    get_register_router=lambda *a, **k: router,
+    get_users_router=lambda *a, **k: router,
+    current_user=lambda active=True: lambda: None,
+    on_after_register=lambda cb: None,
+    on_after_login=lambda cb: None,
+)
+auth_stub.auth_backend = None
+auth_stub.UserCreate = object
+auth_stub.UserRead = object
+auth_stub.UserUpdate = object
+auth_stub.current_active_user = lambda: None
+sys.modules.setdefault('app.auth', auth_stub)
+
+main = importlib.import_module('app.main')
+app = main.app
+with open('docs/openapi.json', 'w') as f:
+    json.dump(app.openapi(), f, indent=2)
+print('OpenAPI spec written to docs/openapi.json')


### PR DESCRIPTION
## Summary
- expand README with API documentation and tutorials
- add script to generate OpenAPI spec
- commit generated `docs/openapi.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768960acd883289f0b753c21ab427a