### PR TITLE
Fix missing async test deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ markdown
 pandas
 weasyprint
 fastapi-users[sqlalchemy]
+
+aiosqlite
+pytest-asyncio


### PR DESCRIPTION
## Summary
- install `aiosqlite` and `pytest-asyncio` in `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768ce9bd548328a053275e25c70b46