### PR TITLE
Update analysis Dockerfile base image

### DIFF
--- a/analysis_service/Dockerfile
+++ b/analysis_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76 as builder
+FROM rust:1.77 as builder
 WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src


### PR DESCRIPTION
## Summary
- bump analysis service base image to `rust:1.77`

## Testing
- `docker-compose build analysis` *(fails: ConnectionRefusedError – Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_6878b9345840832888f97d1c90597bf2