### PR TITLE
Enable Rust in backend container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Install Rust toolchain and libraries needed for custom analysis
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cargo build-essential pkg-config libfontconfig1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ cargo build --release
 ./target/release/analysis_service
 ```
 
+The main backend image now also installs the Rust toolchain and `libfontconfig1-dev` so the `/custom_analysis` endpoint can compile generated code.
+
 Authentication for the admin interface uses HTTP basic auth. Update the OpenRouter API key or model via the `/admin` page.
 
 ### Environment Configuration
@@ -122,6 +124,7 @@ python scripts/generate_openapi.py
 ### Custom Data Analysis
 
 Upload an Excel file and send a prompt to `/custom_analysis`. LinChat will generate and execute Rust code using Polars to return the requested analytics along with a chart in the response headers.
+The Docker image installs Cargo so this compilation works out of the box.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- install Rust and `libfontconfig1-dev` in Dockerfile
- document Rust tooling requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c1752f5c8328b8e2143ad50b6837