### PR TITLE
Add build dependencies to analysis_service Dockerfile

### DIFF
--- a/analysis_service/Dockerfile
+++ b/analysis_service/Dockerfile
@@ -1,4 +1,8 @@
 FROM rust:1.77 as builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pkg-config libfontconfig1-dev build-essential \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src


### PR DESCRIPTION
## Summary
- install pkg-config, libfontconfig1-dev and build-essential in analysis_service build stage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfminer')*

------
https://chatgpt.com/codex/tasks/task_e_6878c8a06738832887b4b0e0e0dd4ad4