### PR TITLE
Add Linux deps install step before Rust build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libfontconfig1-dev
       - name: Build analysis service
         run: cargo build --release
         working-directory: analysis_service


### PR DESCRIPTION
## Summary
- ensure `pkg-config` and `libfontconfig1-dev` are installed before building the Rust analysis service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6878cb90a6e48328b6d761a42b310118