### PR TITLE
Update analysis Dockerfile base image

### DIFF
--- a/analysis_service/Dockerfile
+++ b/analysis_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77 as builder
+FROM rust:1.78 AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         pkg-config libfontconfig1-dev build-essential \


### PR DESCRIPTION
## Summary
- update analysis service Dockerfile to use Rust 1.78 image

## Testing
- `docker-compose build analysis` *(fails: docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6878d0e81e748328b8077ff0f3a2ab37