### PR TITLE
Add multi-stage backend Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,13 @@ pytest_cache/
 frontend/node_modules
 analysis_service/target
 
+# Build artifacts and virtual environments
+build/
+dist/
+*.egg-info
+venv/
+.env/
+
 # Miscellaneous directories not needed in Docker build
 scripts
 k8s

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,43 @@
+# Base image with system dependencies
+FROM python:3.11-slim AS base
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libfontconfig1-dev build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python requirements into an intermediate location
+FROM base AS builder
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --prefix=/install -r requirements.txt && \
+    playwright install --with-deps
+
+# Rust toolchain for runtime compilation
+FROM rust:slim AS rust
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libfontconfig1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Final runtime image
+FROM python:3.11-slim AS runtime
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libfontconfig1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Python dependencies and Rust toolchain
+COPY --from=builder /install /usr/local
+COPY --from=rust /usr/local /usr/local
+ENV PATH="/usr/local/bin:$PATH"
+
+WORKDIR /app
+COPY app ./app
+
+ARG OPENROUTER_API_KEY
+ARG OPENROUTER_MODEL
+ENV OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+ENV OPENROUTER_MODEL=${OPENROUTER_MODEL}
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add a dedicated `Dockerfile.backend` with base, builder, rust, and runtime stages
- copy Rust toolchain and Python deps only into final stage
- set OpenRouter environment variables in runtime
- ignore common build artifacts in `.dockerignore`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f950e3208328a4649f5c697f8e42