### PR TITLE
Update backend compose build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,16 @@
 version: '3.9'
 services:
   backend:
-    build: 
+    build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.backend
+      args:
+        - OPENROUTER_API_KEY
+        - OPENROUTER_MODEL
     environment:
       - ADMIN_PASSWORD=changeme
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+      - OPENROUTER_MODEL=${OPENROUTER_MODEL}
     volumes:
       - ./uploads:/app/uploads
       - ./app/data.db:/app/app/data.db


### PR DESCRIPTION
## Summary
- point backend Dockerfile to `Dockerfile.backend`
- expose `OPENROUTER_API_KEY` and `OPENROUTER_MODEL` as build args and runtime env vars

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfminer')*

------
https://chatgpt.com/codex/tasks/task_e_687902a49c508328a69f0675fcf24c83