### PR TITLE
Update Docker builds to use cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,34 @@ jobs:
     needs: lint-test
     steps:
       - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build backend image
-        run: docker build -t linchat-backend -f Dockerfile .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.backend
+          tags: linchat-backend:ci
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Build analysis image
-        run: docker build -t linchat-analysis -f analysis_service/Dockerfile analysis_service
+        uses: docker/build-push-action@v5
+        with:
+          context: analysis_service
+          file: analysis_service/Dockerfile
+          tags: linchat-analysis:ci
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Build frontend image
-        run: docker build -t linchat-frontend -f frontend/Dockerfile frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: frontend
+          file: frontend/Dockerfile
+          tags: linchat-frontend:ci
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -42,9 +42,11 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.backend
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/linchat-backend:${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and push analysis
         uses: docker/build-push-action@v5
@@ -53,6 +55,8 @@ jobs:
           file: analysis_service/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/linchat-analysis:${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and push frontend
         uses: docker/build-push-action@v5
@@ -61,3 +65,5 @@ jobs:
           file: frontend/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/linchat-frontend:${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- use buildx caching in CI
- cache Docker layers for release builds
- update backend image build path to new Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfminer')*

------
https://chatgpt.com/codex/tasks/task_e_687905404a508328a7a0b03627cbbc1f