### PR TITLE
Improve Docker Compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ docker-compose up --build
 You can also build the images separately and then launch the stack:
 
 ```bash
+OPENROUTER_API_KEY=your-openrouter-key \
+OPENROUTER_MODEL=openrouter/openai/gpt-4o \
 docker-compose build
 docker-compose up
 ```


### PR DESCRIPTION
## Summary
- show explicit environment variables for `docker-compose build`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfminer')*

------
https://chatgpt.com/codex/tasks/task_e_68790ae6cac88328ab3b486e59c8dbea