### PR TITLE
Fix Dockerfile backend Playwright path

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,8 +10,10 @@ FROM base AS builder
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir --prefix=/install -r requirements.txt && \
-    playwright install --with-deps
+    pip install --no-cache-dir --prefix=/install -r requirements.txt
+# Add the installation prefix to PATH so the Playwright CLI is available
+ENV PATH="/install/bin:$PATH"
+RUN playwright install --with-deps
 
 # Rust toolchain for runtime compilation
 FROM rust:slim AS rust


### PR DESCRIPTION
## Summary
- fix path for Playwright CLI in backend Dockerfile

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878d7c57f6c8328a65af5ad793c9d3c