### PR TITLE
Fix PYTHONPATH in backend build

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -11,6 +11,8 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir --prefix=/install -r requirements.txt
+# Make the installed packages available to Python
+ENV PYTHONPATH=/install/lib/python3.11/site-packages
 # Add the installation prefix to PATH so the Playwright CLI is available
 ENV PATH="/install/bin:$PATH"
 RUN playwright install --with-deps


### PR DESCRIPTION
## Summary
- set `PYTHONPATH` in Dockerfile.backend so installed packages are found
- keep PATH export and run Playwright install

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pdfminer, fastapi, bs4)*
- `dockerd` *(fails: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_6879277ec0888328bd47a3e1dfce7523