### PR TITLE
Add libfontconfig1 install in analysis service image

### DIFF
--- a/analysis_service/Dockerfile
+++ b/analysis_service/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
 WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
+RUN apt-get update && apt-get install -y libfontconfig1
 RUN cargo build --release
 
 # The "slim" tag was removed from Docker Hub. Use the official


### PR DESCRIPTION
## Summary
- install `libfontconfig1` in the analysis service Dockerfile

## Testing
- `pip show numpy` *(fails: Package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793c144fe48328b37b4844b3741e4e