### PR TITLE
Fix analysis_service Dockerfile runtime deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ uploads/
 analysis_service/target/
 analysis_agent_*/
 frontend/node_modules/
+app/data.db

--- a/analysis_service/Dockerfile
+++ b/analysis_service/Dockerfile
@@ -12,6 +12,9 @@ RUN cargo build --release
 # The "slim" tag was removed from Docker Hub. Use the official
 # "stable-slim" variant instead (verified via the Docker Hub API).
 FROM debian:stable-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libfontconfig1 \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /usr/src/app/target/release/analysis_service ./analysis_service
 EXPOSE 8001


### PR DESCRIPTION
## Summary
- install `libfontconfig1` in the runtime stage of the analysis service
- ignore test sqlite db file

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `flake8 app`

------
https://chatgpt.com/codex/tasks/task_e_6879548ae1188328b38a574673c2349d