### PR TITLE
Move config helpers to avoid circular import

### DIFF
--- a/app/analysis_agent.py
+++ b/app/analysis_agent.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 import tempfile
 import json
-from .main import _get_api_key, _get_model
+from .config_utils import _get_api_key, _get_model
 import openai
 
 

--- a/app/config_utils.py
+++ b/app/config_utils.py
@@ -1,0 +1,37 @@
+import json
+import os
+from fastapi import HTTPException
+
+CONFIG_DIR = os.path.dirname(__file__)
+ENV = os.getenv("LINCHAT_ENV", "development")
+CONFIG_FILE = os.path.join(CONFIG_DIR, f"config.{ENV}.json")
+DEFAULT_CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
+
+
+def _read_config() -> dict:
+    """Load configuration from file and environment variables."""
+    conf = {}
+    config_path = CONFIG_FILE if os.path.exists(CONFIG_FILE) else DEFAULT_CONFIG_FILE
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            conf.update(json.load(f))
+    env_key = os.getenv("OPENROUTER_API_KEY")
+    if env_key:
+        conf.setdefault("openrouter_api_key", env_key)
+    env_model = os.getenv("OPENROUTER_MODEL")
+    if env_model:
+        conf.setdefault("openrouter_model", env_model)
+    return conf
+
+
+def _get_api_key() -> str:
+    conf = _read_config()
+    key = conf.get("openrouter_api_key")
+    if not key:
+        raise HTTPException(status_code=500, detail="OpenRouter API key not configured")
+    return key
+
+
+def _get_model() -> str:
+    conf = _read_config()
+    return conf.get("openrouter_model", "openai/gpt-3.5-turbo")

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,8 @@ import os
 import re
 import logging
 
+from .config_utils import _get_api_key, _get_model
+
 from .logging_setup import setup_logging
 
 from .db import (
@@ -24,7 +26,6 @@ from .db import (
 from .ingest import parse_file
 from . import vector_db
 from .scraper import scrape_url, scrape_search
-from .analysis_agent import run_custom_analysis
 from .reporting import (
     generate_summary,
     generate_table,
@@ -138,17 +139,6 @@ def _write_config(conf: dict) -> None:
         json.dump(conf, f, indent=2)
 
 
-def _get_api_key() -> str:
-    conf = _read_config()
-    key = conf.get("openrouter_api_key")
-    if not key:
-        raise HTTPException(status_code=500, detail="OpenRouter API key not configured")
-    return key
-
-
-def _get_model() -> str:
-    conf = _read_config()
-    return conf.get("openrouter_model", "openai/gpt-3.5-turbo")
 
 
 def _require_admin(credentials: HTTPBasicCredentials = Depends(security)):
@@ -160,6 +150,9 @@ def _require_admin(credentials: HTTPBasicCredentials = Depends(security)):
     if credentials.username != username or credentials.password != password:
         raise HTTPException(status_code=401, detail="Unauthorized")
     return True
+
+
+from .analysis_agent import run_custom_analysis
 
 
 @app.post("/query")


### PR DESCRIPTION
## Summary
- create `config_utils` with `_get_api_key` and `_get_model`
- pull config helpers from new module in `main.py` and `analysis_agent.py`
- delay `run_custom_analysis` import until after config is loaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796b2d46388328950c5cc660a0ab22