### PR TITLE
Pin httpx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chromadb
 sentence-transformers
 playwright
 beautifulsoup4
-httpx
+httpx<0.28
 markdown
 pandas
 weasyprint


### PR DESCRIPTION
## Summary
- pin `httpx` to `<0.28` to maintain compatibility with FastAPI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796e3a17308328be05793ad68f73da