### PR TITLE
Add frontend API helpers for auth and admin

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -54,6 +54,26 @@ export async function exportPdf(content) {
   return URL.createObjectURL(blob);
 }
 
+export async function loginUser(username, password) {
+  const res = await fetch('/auth/jwt/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function registerUser(user) {
+  const res = await fetch('/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(user)
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
 
 export async function getDocuments() {
   const res = await fetch('/documents');
@@ -70,6 +90,21 @@ export async function deleteDocument(id) {
 
 export async function setShared(id, shared) {
   const res = await fetch(`/documents/${id}/share?shared=${shared}`, { method: 'POST' });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function getAdminData() {
+  const res = await fetch('/admin/data');
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function setApiKey(key, model) {
+  const form = new FormData();
+  form.append('key', key);
+  if (model) form.append('model', model);
+  const res = await fetch('/admin/set_key', { method: 'POST', body: form });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }


### PR DESCRIPTION
## Summary
- implement `loginUser` and `registerUser` helpers
- add admin endpoints `getAdminData` and `setApiKey`
- run frontend build and python tests

## Testing
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fb1807c88328a43b6d748621b0bf