### PR TITLE
Fix WeasyPrint runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 # Install Rust toolchain and libraries needed for custom analysis
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cargo build-essential pkg-config libfontconfig1-dev \
+        libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+        libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -3,6 +3,8 @@ FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config libfontconfig1-dev build-essential \
+        libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+        libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python requirements into an intermediate location
@@ -21,6 +23,8 @@ RUN playwright install --with-deps
 FROM rust:slim AS rust
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config libfontconfig1-dev \
+        libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+        libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Final runtime image
@@ -28,6 +32,8 @@ FROM python:3.11-slim AS runtime
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config libfontconfig1-dev \
+        libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+        libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Python dependencies and Rust toolchain


### PR DESCRIPTION
## Summary
- add missing WeasyPrint libraries to backend Dockerfile
- also update main Dockerfile with same packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fc4637bc8328993ce4c7f974953f