### PR TITLE
Enable configurable API base for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     build:
       context: frontend
       dockerfile: Dockerfile
+      args:
+        - VITE_API_URL=${VITE_API_URL}
     ports:
       - "3000:80"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20 AS build
 WORKDIR /app
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,3 +10,12 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Configuration
+
+The frontend expects the backend URL in the `VITE_API_URL` environment variable when building the static files. If omitted, requests default to `http://localhost:8000`.
+
+```bash
+VITE_API_URL="http://localhost:8000" npm run build
+```
+

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,7 @@
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
 export async function queryLLM(prompt) {
-  const res = await fetch('/query', {
+  const res = await fetch(`${API_BASE}/query`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ prompt })
@@ -12,13 +14,13 @@ export async function uploadFile(file, shared=false) {
   const form = new FormData();
   form.append('file', file);
   form.append('shared', shared);
-  const res = await fetch('/upload', { method: 'POST', body: form });
+  const res = await fetch(`${API_BASE}/upload`, { method: 'POST', body: form });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
 export async function generateTable(prompt) {
-  const res = await fetch('/generate_table', {
+  const res = await fetch(`${API_BASE}/generate_table`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ prompt })
@@ -38,13 +40,13 @@ export async function analyzeFile(file) {
 }
 
 export async function getCitation(reqId, cid) {
-  const res = await fetch(`/source/${reqId}/${cid}`);
+  const res = await fetch(`${API_BASE}/source/${reqId}/${cid}`);
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
 export async function exportPdf(content) {
-  const res = await fetch('/export/pdf', {
+  const res = await fetch(`${API_BASE}/export/pdf`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content })
@@ -55,7 +57,7 @@ export async function exportPdf(content) {
 }
 
 export async function loginUser(username, password) {
-  const res = await fetch('/auth/jwt/login', {
+  const res = await fetch(`${API_BASE}/auth/jwt/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password })
@@ -65,7 +67,7 @@ export async function loginUser(username, password) {
 }
 
 export async function registerUser(user) {
-  const res = await fetch('/auth/register', {
+  const res = await fetch(`${API_BASE}/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(user)
@@ -76,26 +78,26 @@ export async function registerUser(user) {
 
 
 export async function getDocuments() {
-  const res = await fetch('/documents');
+  const res = await fetch(`${API_BASE}/documents`);
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
 export async function deleteDocument(id) {
-  const res = await fetch(`/documents/${id}`, { method: 'DELETE' });
+  const res = await fetch(`${API_BASE}/documents/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
 
 export async function setShared(id, shared) {
-  const res = await fetch(`/documents/${id}/share?shared=${shared}`, { method: 'POST' });
+  const res = await fetch(`${API_BASE}/documents/${id}/share?shared=${shared}`, { method: 'POST' });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
 export async function getAdminData() {
-  const res = await fetch('/admin/data');
+  const res = await fetch(`${API_BASE}/admin/data`);
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
@@ -104,7 +106,7 @@ export async function setApiKey(key, model) {
   const form = new FormData();
   form.append('key', key);
   if (model) form.append('model', model);
-  const res = await fetch('/admin/set_key', { method: 'POST', body: form });
+  const res = await fetch(`${API_BASE}/admin/set_key`, { method: 'POST', body: form });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }


### PR DESCRIPTION
## Summary
- let frontend API endpoints share a common base URL
- set up Docker to pass `VITE_API_URL` for the build
- document the new variable in the frontend README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fe8274e08328a79c7ade3e58fdf2