### PR TITLE
Update backend port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./uploads:/app/uploads
       - ./data:/data
     ports:
-      - "8000:8000"
+      - "8002:8002"
     depends_on:
       - analysis
   analysis:


### PR DESCRIPTION
## Summary
- use port mapping `8002:8002` for the backend service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a08516e408328a0ab29ae07245406