### PR TITLE
Fix port conflict

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,5 @@
   "runServices": ["backend", "analysis", "frontend"],
   "workspaceFolder": "/workspace/LinChat",
   "postCreateCommand": "pip install -r requirements.txt && cd frontend && npm ci",
-  "forwardPorts": [8080, 8000, 8001]
+  "forwardPorts": [8080, 8002, 8001]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./uploads:/app/uploads
       - ./data:/data
     ports:
-      - "8002:8002"
+      - "8002:8000"
     depends_on:
       - analysis
   analysis:


### PR DESCRIPTION
## Summary
- map the backend service to `8002:8000`
- update devcontainer to forward port `8002`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1eccddc4832897552fa967ebaa65