### PR TITLE
Clarify Calamine helper usage

### DIFF
--- a/analysis_service/src/main.rs
+++ b/analysis_service/src/main.rs
@@ -31,9 +31,11 @@ async fn analyze(mut multipart: Multipart) -> Result<Response, StatusCode> {
     info!("received analysis request");
 
     let data = data.ok_or(StatusCode::BAD_REQUEST)?;
-    // Read Excel data using calamine and convert to Polars DataFrame
+    // Read Excel data using calamine. `open_workbook_auto_from_rs` is the helper
+    // for opening a workbook from an in-memory cursor.
     let cursor = std::io::Cursor::new(data);
-    let mut workbook = open_workbook_auto_from_rs(cursor).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let mut workbook = open_workbook_auto_from_rs(cursor)
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
     let sheet_name = workbook.sheet_names().get(0).cloned().ok_or(StatusCode::BAD_REQUEST)?;
     let range = workbook.worksheet_range(&sheet_name).map_err(|_| StatusCode::BAD_REQUEST)?;
 


### PR DESCRIPTION
## Summary
- clarify comment about using `open_workbook_auto_from_rs` for in-memory Excel data

## Testing
- `pytest -q`
- `cargo build --quiet` in `analysis_service`

------
https://chatgpt.com/codex/tasks/task_e_687a21aaafbc8328b56a0bf0dee93e2b