### PR TITLE
Expand admin dashboard

### DIFF
--- a/frontend/src/admin/AdminDashboard.jsx
+++ b/frontend/src/admin/AdminDashboard.jsx
@@ -1,13 +1,18 @@
 import { useEffect, useState } from 'react'
-import { TextField, Button, Box } from '@mui/material'
+import { TextField, Button, Box, Snackbar } from '@mui/material'
 import UserTable from './UserTable.jsx'
 import AuditLogTable from './AuditLogTable.jsx'
-import { getAdminData, setApiKey } from '../api.js'
+import WorkspaceTable from './WorkspaceTable.jsx'
+import { getAdminData, setApiKey, inviteUser, resetPassword, createWorkspace, deleteWorkspace } from '../api.js'
 
 export default function AdminDashboard() {
-  const [data, setData] = useState({ users: [], logs: [], key: '', model: '' })
+  const [data, setData] = useState({ users: [], logs: [], key: '', model: '', workspaces: [] })
   const [key, setKey] = useState('')
   const [model, setModel] = useState('')
+  const [saved, setSaved] = useState(false)
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [workspaceName, setWorkspaceName] = useState('')
+  const [filter, setFilter] = useState('')
 
   useEffect(() => {
     getAdminData().then(d => {
@@ -20,7 +25,38 @@ export default function AdminDashboard() {
   const handleSave = async e => {
     e.preventDefault()
     await setApiKey(key, model)
+    setSaved(true)
   }
+
+  const handleInvite = async e => {
+    e.preventDefault()
+    const res = await inviteUser(inviteEmail)
+    alert(`Password: ${res.password}`)
+    setInviteEmail('')
+    const updated = await getAdminData()
+    setData(updated)
+  }
+
+  const handleReset = async id => {
+    const res = await resetPassword(id)
+    alert(`New password: ${res.password}`)
+  }
+
+  const handleCreateWs = async e => {
+    e.preventDefault()
+    const ws = await createWorkspace(workspaceName)
+    setData(d => ({ ...d, workspaces: [...d.workspaces, ws] }))
+    setWorkspaceName('')
+  }
+
+  const handleDeleteWs = async id => {
+    await deleteWorkspace(id)
+    setData(d => ({ ...d, workspaces: d.workspaces.filter(w => w.id !== id) }))
+  }
+
+  const filteredLogs = data.logs.filter(l =>
+    l.action.toLowerCase().includes(filter.toLowerCase()) || String(l.user_id).includes(filter)
+  )
 
   return (
     <Box sx={{maxWidth:600, margin:'auto', padding:2}}>
@@ -30,8 +66,19 @@ export default function AdminDashboard() {
         <TextField label="Model" value={model} onChange={e=>setModel(e.target.value)} fullWidth margin="normal" />
         <Button type="submit" variant="contained">Save</Button>
       </form>
-      <UserTable users={data.users} />
-      <AuditLogTable logs={data.logs} />
+      <form onSubmit={handleInvite} style={{marginBottom:'1rem'}}>
+        <TextField label="Invite Email" value={inviteEmail} onChange={e=>setInviteEmail(e.target.value)} fullWidth margin="normal" />
+        <Button type="submit" variant="contained">Invite</Button>
+      </form>
+      <form onSubmit={handleCreateWs} style={{marginBottom:'1rem'}}>
+        <TextField label="New Workspace" value={workspaceName} onChange={e=>setWorkspaceName(e.target.value)} fullWidth margin="normal" />
+        <Button type="submit" variant="contained">Create</Button>
+      </form>
+      <UserTable users={data.users} onReset={handleReset} />
+      <WorkspaceTable workspaces={data.workspaces} onDelete={handleDeleteWs} />
+      <TextField label="Filter logs" value={filter} onChange={e=>setFilter(e.target.value)} fullWidth margin="normal" />
+      <AuditLogTable logs={filteredLogs} />
+      <Snackbar open={saved} autoHideDuration={2000} onClose={()=>setSaved(false)} message="Saved" />
     </Box>
   )
 }

--- a/frontend/src/admin/UserTable.jsx
+++ b/frontend/src/admin/UserTable.jsx
@@ -1,6 +1,6 @@
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material'
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Button } from '@mui/material'
 
-export default function UserTable({ users }) {
+export default function UserTable({ users, onReset }) {
   return (
     <TableContainer component={Paper} sx={{marginTop:2}}>
       <Table size="small">
@@ -8,6 +8,7 @@ export default function UserTable({ users }) {
           <TableRow>
             <TableCell>ID</TableCell>
             <TableCell>Email</TableCell>
+            <TableCell></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -15,6 +16,7 @@ export default function UserTable({ users }) {
             <TableRow key={u.id}>
               <TableCell>{u.id}</TableCell>
               <TableCell>{u.email}</TableCell>
+              <TableCell><Button size="small" onClick={() => onReset(u.id)}>Reset</Button></TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/frontend/src/admin/WorkspaceTable.jsx
+++ b/frontend/src/admin/WorkspaceTable.jsx
@@ -1,0 +1,31 @@
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, IconButton } from '@mui/material'
+import DeleteIcon from '@mui/icons-material/Delete'
+
+export default function WorkspaceTable({ workspaces, onDelete }) {
+  return (
+    <TableContainer component={Paper} sx={{marginTop:2}}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {workspaces.map(w => (
+            <TableRow key={w.id}>
+              <TableCell>{w.id}</TableCell>
+              <TableCell>{w.name}</TableCell>
+              <TableCell>
+                <IconButton size="small" onClick={() => onDelete(w.id)}>
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -110,3 +110,34 @@ export async function setApiKey(key, model) {
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
+
+export async function inviteUser(email, teamId) {
+  const form = new FormData();
+  form.append('email', email);
+  if (teamId) form.append('team_id', teamId);
+  const res = await fetch(`${API_BASE}/admin/invite`, { method: 'POST', body: form });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function resetPassword(userId) {
+  const form = new FormData();
+  form.append('user_id', userId);
+  const res = await fetch(`${API_BASE}/admin/reset_password`, { method: 'POST', body: form });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function createWorkspace(name) {
+  const form = new FormData();
+  form.append('name', name);
+  const res = await fetch(`${API_BASE}/admin/workspaces`, { method: 'POST', body: form });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function deleteWorkspace(id) {
+  const res = await fetch(`${API_BASE}/admin/workspaces/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add admin endpoints for inviting users, resetting passwords and workspace management
- allow admin data endpoint to return workspaces
- handle new admin features in React dashboard
- show API key save status, audit log filtering and user reset option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4f5da8f483289258a2d2d0ee51dd