### PR TITLE
Add workspace scoping and management

### DIFF
--- a/app/scraper/service.py
+++ b/app/scraper/service.py
@@ -29,7 +29,7 @@ def _extract_text(html: str) -> str:
     return "\n".join(t.strip() for t in texts if t.strip())
 
 
-async def scrape_url(url: str) -> Optional[str]:
+async def scrape_url(url: str, workspace_id: int | None = None) -> Optional[str]:
     """Fetch the given URL and store its contents in the vector DB."""
     try:
         html = await _fetch_html(url)
@@ -39,11 +39,13 @@ async def scrape_url(url: str) -> Optional[str]:
     if not text:
         return None
     # Store in vector DB with url metadata
-    vector_db.add_web_embeddings(url, text)
+    vector_db.add_web_embeddings(url, text, workspace_id=workspace_id)
     return text
 
 
-async def scrape_search(query: str, max_results: int = 1) -> List[str]:
+async def scrape_search(
+    query: str, max_results: int = 1, workspace_id: int | None = None
+) -> List[str]:
     """Search DuckDuckGo and scrape the top results."""
     import httpx
 
@@ -54,7 +56,7 @@ async def scrape_search(query: str, max_results: int = 1) -> List[str]:
     links = [a["href"] for a in soup.select("a.result__a") if a.get("href")]
     scraped = []
     for url in links[:max_results]:
-        content = await scrape_url(url)
+        content = await scrape_url(url, workspace_id=workspace_id)
         if content:
             scraped.append(url)
     return scraped

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -75,7 +75,11 @@ def test_upload_and_query(monkeypatch, tmp_path):
     assert resp.status_code == 200
     assert resp.json()["document_id"] == 1
 
-    monkeypatch.setattr(main.vector_db, "get_context", lambda prompt, top_k=5: ("ctx", []))
+    monkeypatch.setattr(
+        main.vector_db,
+        "get_context",
+        lambda prompt, top_k=5, allowed_ids=None, workspace_id=None: ("ctx", []),
+    )
     class Resp:
         choices = [type("C", (), {"message": {"content": "answer"}})]
     def fake_create(**kwargs):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -52,7 +52,11 @@ async def test_query_llm(monkeypatch):
     monkeypatch.setattr(config, "_get_api_key", lambda: "key")
     main.logger = types.SimpleNamespace(info=lambda *a, **k: None)
     monkeypatch.setattr(main, "add_audit_log", lambda *a, **k: None)
-    monkeypatch.setattr(main.vector_db, "get_context", lambda prompt, top_k=5: ("ctx", []))
+    monkeypatch.setattr(
+        main.vector_db,
+        "get_context",
+        lambda prompt, top_k=5, allowed_ids=None, workspace_id=None: ("ctx", []),
+    )
     class Resp:
         choices = [type("C", (), {"message": {"content": "answer"}})]
     def fake_create(**kwargs):

--- a/tests/test_vector_db.py
+++ b/tests/test_vector_db.py
@@ -35,8 +35,8 @@ def test_add_and_query(monkeypatch):
     monkeypatch.setattr(vector_db, "_get_collection", lambda: collection)
     monkeypatch.setattr(vector_db, "_get_model", lambda: DummyModel())
 
-    vector_db.add_embeddings(1, [{"page": 1, "text": "hello"}])
-    res = vector_db.query("hello", top_k=1)
+    vector_db.add_embeddings(1, [{"page": 1, "text": "hello"}], workspace_id=1)
+    res = vector_db.query("hello", top_k=1, workspace_id=1)
     assert res and res[0]["text"] == "hello"
 
 
@@ -45,6 +45,6 @@ def test_add_web_embeddings(monkeypatch):
     monkeypatch.setattr(vector_db, "_get_collection", lambda: collection)
     monkeypatch.setattr(vector_db, "_get_model", lambda: DummyModel())
 
-    vector_db.add_web_embeddings("http://example.com", "web text")
-    res = vector_db.query("web", top_k=1)
+    vector_db.add_web_embeddings("http://example.com", "web text", workspace_id=2)
+    res = vector_db.query("web", top_k=1, workspace_id=2)
     assert res and res[0]["url"] == "http://example.com"


### PR DESCRIPTION
## Summary
- support workspace metadata in vector database and search functions
- allow scraping functions and document uploads to pass workspace IDs
- expose new endpoints for workspace creation and user assignment
- update tests for new signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b5ebbe3148328944424458475e840