### PR TITLE
Add admin utility endpoints and secure API key

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,21 @@ def _write_config(conf: dict) -> None:
         json.dump(conf, f, indent=2)
 
 
+def set_openrouter_credentials(key: str, model: str | None = None) -> None:
+    """Persist OpenRouter API credentials using the config helpers."""
+    conf = _read_config()
+    conf["openrouter_api_key"] = key
+    if model is not None:
+        conf["openrouter_model"] = model
+    _write_config(conf)
+
+
+def has_openrouter_key() -> bool:
+    """Check if an API key is configured without exposing it."""
+    conf = _read_config()
+    return bool(conf.get("openrouter_api_key"))
+
+
 def _get_api_key() -> str:
     conf = _read_config()
     key = conf.get("openrouter_api_key")

--- a/app/main.py
+++ b/app/main.py
@@ -261,7 +261,7 @@ async def scrape_endpoint(url: str = None, query: str = None):
 @app.get("/admin/data")
 async def admin_data(auth: bool = Depends(_require_admin)):
     conf = config._read_config()
-    key = conf.get("openrouter_api_key", "")
+    has_key = config.has_openrouter_key()
     model = conf.get("openrouter_model", config._get_model())
     async with async_session_maker() as session:
         users = (await session.execute(select(User))).scalars().all()
@@ -272,7 +272,7 @@ async def admin_data(auth: bool = Depends(_require_admin)):
             )
         ).scalars().all()
     return {
-        "key": key,
+        "has_key": has_key,
         "model": model,
         "users": [{"id": u.id, "email": u.email} for u in users],
         "workspaces": [{"id": t.id, "name": t.name} for t in teams],
@@ -294,11 +294,7 @@ def set_key(
     model: str = Form(None),
     auth: bool = Depends(_require_admin),
 ):
-    conf = config._read_config()
-    conf["openrouter_api_key"] = key
-    if model:
-        conf["openrouter_model"] = model
-    config._write_config(conf)
+    config.set_openrouter_credentials(key, model)
     return {"status": "saved"}
 
 

--- a/frontend/src/admin/AdminDashboard.jsx
+++ b/frontend/src/admin/AdminDashboard.jsx
@@ -6,7 +6,7 @@ import WorkspaceTable from './WorkspaceTable.jsx'
 import { getAdminData, setApiKey, inviteUser, resetPassword, createWorkspace, deleteWorkspace } from '../api.js'
 
 export default function AdminDashboard() {
-  const [data, setData] = useState({ users: [], logs: [], key: '', model: '', workspaces: [] })
+  const [data, setData] = useState({ users: [], logs: [], has_key: false, model: '', workspaces: [] })
   const [key, setKey] = useState('')
   const [model, setModel] = useState('')
   const [saved, setSaved] = useState(false)
@@ -17,7 +17,7 @@ export default function AdminDashboard() {
   useEffect(() => {
     getAdminData().then(d => {
       setData(d)
-      setKey(d.key)
+      setKey(d.has_key ? '********' : '')
       setModel(d.model)
     })
   }, [])


### PR DESCRIPTION
## Summary
- save OpenRouter credentials through config helpers
- report only the existence of the key via `/admin/data`
- wire up admin dashboard to mask stored keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b67c288b88328b70cf7ebd8d44ea4