### PR TITLE
Implement chat logging and PDF export

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -44,3 +44,25 @@ class AuditLog(Base):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"))
     action: Mapped[str] = mapped_column(String)
     timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class ChatThread(Base):
+    __tablename__ = "chat_threads"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"))
+    workspace_id: Mapped[Optional[int]] = mapped_column(ForeignKey("teams.id"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    messages = relationship("ChatMessage", back_populates="thread")
+
+
+class ChatMessage(Base):
+    __tablename__ = "chat_messages"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    thread_id: Mapped[int] = mapped_column(ForeignKey("chat_threads.id"))
+    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"))
+    role: Mapped[str] = mapped_column(String)
+    content: Mapped[str] = mapped_column(String)
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    thread = relationship("ChatThread", back_populates="messages")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,6 +85,43 @@ def test_upload_and_query(monkeypatch, tmp_path):
     def fake_create(**kwargs):
         return Resp()
     monkeypatch.setattr(main.openai.ChatCompletion, "create", fake_create)
+    class DummyModel:
+        def __init__(self, *a, **k):
+            self.id = 1
+
+    monkeypatch.setattr(main, "ChatThread", DummyModel)
+    monkeypatch.setattr(main, "ChatMessage", DummyModel)
+    class DummyScalar:
+        def all(self):
+            return []
+
+    class DummyResult:
+        def scalars(self):
+            return DummyScalar()
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def add(self, *a, **k):
+            pass
+
+        async def commit(self):
+            pass
+
+        async def refresh(self, *a, **k):
+            pass
+
+        async def get(self, *a, **k):
+            return None
+
+        async def execute(self, *a, **k):
+            return DummyResult()
+
+    monkeypatch.setattr(main, "async_session_maker", lambda: DummySession())
     CITATION_STORE.clear()
     resp = client.post("/query", params={"prompt": "hi"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `ChatThread` and `ChatMessage` models
- track chat prompts and responses in `/query`
- create `/chat/sessions` endpoint for new threads
- export whole chats through `/chat/{session_id}/export/pdf`
- adjust tests for new async DB calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b6eb293c483289ef4b1661de8ef3a