### PR TITLE
Frontend chat improvements

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.2.0",
+        "@mui/x-data-grid": "^7.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1"
@@ -1377,6 +1378,64 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-data-grid": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.29.8.tgz",
+      "integrity": "sha512-m4Dp1Vig8gFiBlcEOWimUku182cEw5YrAyXS3PfTSdbxa/20bFw7a8mlHdxO9ChHQRMf6TqbisdRm23CDIIdog==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+        "@mui/x-internals": "7.29.0",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
+      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3130,6 +3189,12 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3370,6 +3435,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.2.0",
+    "@mui/x-data-grid": "^7.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Link } from 'react-router-dom'
 import { AppBar, Toolbar, Button } from '@mui/material'
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
+import ChatPage from './pages/Chat.jsx'
 import Login from './Login.jsx'
 import Register from './Register.jsx'
 import AdminDashboard from './admin/AdminDashboard.jsx'
@@ -16,6 +17,7 @@ export default function App() {
         <Toolbar>
           <Button color="inherit" component={Link} to="/">Home</Button>
           <Button color="inherit" component={Link} to="/documents">Documents</Button>
+          <Button color="inherit" component={Link} to="/chat">Chat</Button>
           {token && <Button color="inherit" component={Link} to="/admin">Admin</Button>}
           <Button color="inherit" component={Link} to="/login">Login</Button>
           <Button color="inherit" component={Link} to="/register">Register</Button>
@@ -24,6 +26,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/documents" element={<Documents />} />
+        <Route path="/chat" element={<ChatPage />} />
         <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />

--- a/frontend/src/admin/AuditLogTable.jsx
+++ b/frontend/src/admin/AuditLogTable.jsx
@@ -1,26 +1,27 @@
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material'
+import { Box } from '@mui/material'
+import { DataGrid } from '@mui/x-data-grid'
 
 export default function AuditLogTable({ logs }) {
+  const columns = [
+    {
+      field: 'timestamp',
+      headerName: 'Time',
+      flex: 1,
+      valueGetter: params => new Date(params.row.timestamp).toLocaleString(),
+    },
+    { field: 'user_id', headerName: 'User', width: 80 },
+    { field: 'action', headerName: 'Action', flex: 1 },
+  ]
+
   return (
-    <TableContainer component={Paper} sx={{marginTop:2}}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Time</TableCell>
-            <TableCell>User</TableCell>
-            <TableCell>Action</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {logs.map(l => (
-            <TableRow key={l.id}>
-              <TableCell>{new Date(l.timestamp).toLocaleString()}</TableCell>
-              <TableCell>{l.user_id}</TableCell>
-              <TableCell>{l.action}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <Box sx={{ mt: 2 }}>
+      <DataGrid
+        autoHeight
+        rows={logs}
+        columns={columns}
+        disableRowSelectionOnClick
+        density="compact"
+      />
+    </Box>
   )
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,10 +1,10 @@
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
-export async function queryLLM(prompt) {
+export async function queryLLM(prompt, sessionId) {
   const res = await fetch(`${API_BASE}/query`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ prompt })
+    body: JSON.stringify({ prompt, session_id: sessionId })
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
@@ -54,6 +54,18 @@ export async function exportPdf(content) {
   if (!res.ok) throw new Error(await res.text());
   const blob = await res.blob();
   return URL.createObjectURL(blob);
+}
+
+export async function createChatSession() {
+  const res = await fetch(`${API_BASE}/chat/sessions`, { method: 'POST' });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function getWorkspaces() {
+  const res = await fetch(`${API_BASE}/workspaces`);
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 }
 
 export async function loginUser(username, password) {

--- a/frontend/src/components/ChatView.jsx
+++ b/frontend/src/components/ChatView.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { Box, Button, TextField, Paper, Typography, Link } from '@mui/material'
+import { createChatSession, queryLLM, exportPdf } from '../api.js'
+
+export default function ChatView() {
+  const [sessionId, setSessionId] = useState(null)
+  const [prompt, setPrompt] = useState('')
+  const [messages, setMessages] = useState([])
+  const [pdfUrl, setPdfUrl] = useState(null)
+
+  useEffect(() => {
+    createChatSession().then(res => setSessionId(res.id))
+  }, [])
+
+  async function handleSend(e) {
+    e.preventDefault()
+    if (!prompt) return
+    setMessages(m => [...m, { role: 'user', content: prompt }])
+    try {
+      const res = await queryLLM(prompt, sessionId)
+      setMessages(m => [...m, { role: 'assistant', content: res.response }])
+    } catch (err) {
+      setMessages(m => [...m, { role: 'assistant', content: err.toString() }])
+    }
+    setPrompt('')
+  }
+
+  async function handleExport() {
+    const text = messages
+      .map(m => `**${m.role === 'user' ? 'User' : 'Assistant'}:** ${m.content}`)
+      .join('\n\n')
+    const link = await exportPdf(text)
+    setPdfUrl(link)
+  }
+
+  return (
+    <Box>
+      <Box component="form" onSubmit={handleSend} sx={{ mb: 2, display: 'flex', gap: 1 }}>
+        <TextField value={prompt} onChange={e => setPrompt(e.target.value)} fullWidth size="small" />
+        <Button type="submit" variant="contained">Send</Button>
+      </Box>
+      {messages.map((m, idx) => (
+        <Paper key={idx} sx={{ p: 1, mb: 1 }}>
+          <Typography variant="subtitle2" component="span">
+            {m.role === 'user' ? 'User:' : 'Assistant:'}
+          </Typography>{' '}
+          <span dangerouslySetInnerHTML={{ __html: m.content }} />
+        </Paper>
+      ))}
+      <Button variant="contained" onClick={handleExport} sx={{ mt: 2 }}>
+        Export PDF
+      </Button>
+      {pdfUrl && (
+        <Link href={pdfUrl} download="chat.pdf" sx={{ ml: 1 }}>
+          Download
+        </Link>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/components/WorkspaceSelector.jsx
+++ b/frontend/src/components/WorkspaceSelector.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import { FormControl, InputLabel, Select, MenuItem } from '@mui/material'
+import { getWorkspaces } from '../api.js'
+
+export default function WorkspaceSelector({ onChange }) {
+  const [workspaces, setWorkspaces] = useState([])
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    getWorkspaces().then(res => setWorkspaces(res.workspaces))
+  }, [])
+
+  const handleChange = e => {
+    setValue(e.target.value)
+    if (onChange) onChange(e.target.value)
+  }
+
+  return (
+    <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+      <InputLabel id="ws-label">Workspace</InputLabel>
+      <Select labelId="ws-label" value={value} label="Workspace" onChange={handleChange}>
+        {workspaces.map(ws => (
+          <MenuItem key={ws.id} value={ws.id}>{ws.name}</MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+import WorkspaceSelector from '../components/WorkspaceSelector.jsx'
+import ChatView from '../components/ChatView.jsx'
+import { Container } from '@mui/material'
+
+export default function ChatPage() {
+  const [ws, setWs] = useState(null)
+  return (
+    <Container sx={{ mt: 2 }}>
+      <WorkspaceSelector onChange={setWs} />
+      {ws && <ChatView key={ws} />}
+    </Container>
+  )
+}

--- a/frontend/src/pages/Documents.jsx
+++ b/frontend/src/pages/Documents.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { Box, Button } from '@mui/material'
+import { DataGrid } from '@mui/x-data-grid'
 import { getDocuments, deleteDocument, setShared } from '../api.js'
 
 export default function Documents() {
@@ -28,34 +30,43 @@ export default function Documents() {
     setDocs(docs.map(d => (d.id === id ? { ...d, is_shared: res.is_shared } : d)))
   }
 
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 70 },
+    { field: 'filename', headerName: 'Filename', flex: 1 },
+    {
+      field: 'is_shared',
+      headerName: 'Shared',
+      width: 90,
+      valueGetter: params => (params.row.is_shared ? 'Yes' : 'No'),
+    },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      width: 180,
+      sortable: false,
+      renderCell: params => (
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button size="small" onClick={() => handleDelete(params.row.id)}>
+            Delete
+          </Button>
+          <Button size="small" onClick={() => handleToggle(params.row.id, params.row.is_shared)}>
+            {params.row.is_shared ? 'Unshare' : 'Share'}
+          </Button>
+        </Box>
+      ),
+    },
+  ]
+
   return (
-    <div>
+    <Box>
       <h2>Documents</h2>
-      <table border="1">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Filename</th>
-            <th>Shared</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {docs.map(d => (
-            <tr key={d.id}>
-              <td>{d.id}</td>
-              <td>{d.filename}</td>
-              <td>{d.is_shared ? 'Yes' : 'No'}</td>
-              <td>
-                <button onClick={() => handleDelete(d.id)}>Delete</button>
-                <button onClick={() => handleToggle(d.id, d.is_shared)} style={{ marginLeft: '0.5rem' }}>
-                  {d.is_shared ? 'Unshare' : 'Share'}
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+      <DataGrid
+        autoHeight
+        rows={docs}
+        columns={columns}
+        disableRowSelectionOnClick
+        density="compact"
+      />
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary
- modernize Documents and Audit Logs tables using MUI DataGrid
- introduce workspace selector and chat view components
- allow chat exports through `/export/pdf`
- wire new Chat page into router
- add DataGrid dependency

## Testing
- `pytest -q`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_687ba03967ec832889738f979a6dca8e