### PR TITLE
Fix flake8 blank line error

### DIFF
--- a/app/analysis_service_client.py
+++ b/app/analysis_service_client.py
@@ -4,6 +4,7 @@ from typing import Tuple, List, Dict
 
 SERVICE_URL = os.getenv("ANALYSIS_SERVICE_URL", "http://localhost:8001/analysis")
 
+
 async def analyze_file(path: str) -> Tuple[List[Dict], str | None]:
     """Upload a file to the Rust analysis service and return stats and chart."""
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary
- fix E302 violation in `analysis_service_client.py`

## Testing
- `flake8 app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd8e7a580832892370484ec57990d