### PR TITLE
Add branding theme and logo to frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Link } from 'react-router-dom'
-import { AppBar, Toolbar, Button } from '@mui/material'
+import { AppBar, Toolbar, Button, Box } from '@mui/material'
+import logo from './assets/logo.svg'
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
 import ChatPage from './pages/Chat.jsx'
@@ -13,8 +14,9 @@ export default function App() {
 
   return (
     <>
-      <AppBar position="static">
+      <AppBar position="static" color="primary">
         <Toolbar>
+          <Box component="img" src={logo} alt="LinChat" sx={{ height: 32, mr: 2 }} />
           <Button color="inherit" component={Link} to="/">Home</Button>
           <Button color="inherit" component={Link} to="/documents">Documents</Button>
           <Button color="inherit" component={Link} to="/chat">Chat</Button>

--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="#1976d2"/>
+  <text x="50%" y="55%" text-anchor="middle" font-size="40" fill="#fff" font-family="Arial, sans-serif">LC</text>
+</svg>

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,8 +1,29 @@
 import { createTheme } from '@mui/material/styles'
 
 const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+      light: '#42a5f5',
+      dark: '#1565c0',
+    },
+    secondary: {
+      main: '#ff4081',
+    },
+  },
   typography: {
-    fontFamily: 'Arial, sans-serif',
+    fontFamily: '"Open Sans", Arial, sans-serif',
+    h1: {
+      fontSize: '2rem',
+      fontWeight: 700,
+    },
+    h2: {
+      fontSize: '1.5rem',
+      fontWeight: 700,
+    },
+    body1: {
+      fontSize: '1rem',
+    },
   },
   components: {
     MuiContainer: {


### PR DESCRIPTION
## Summary
- add LinChat logo asset
- extend MUI theme with colors and typography
- show logo in app bar using new theme

## Testing
- `npm run lint`
- `flake8 app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bffcd62088328ae53f99f1fe00196