### PR TITLE
Add sidebar layout with workspace selector

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,36 +1,24 @@
-import { Routes, Route, Link } from 'react-router-dom'
-import { AppBar, Toolbar, Button } from '@mui/material'
+import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
 import ChatPage from './pages/Chat.jsx'
 import Login from './Login.jsx'
 import Register from './Register.jsx'
 import AdminDashboard from './admin/AdminDashboard.jsx'
+import AppLayout from './components/AppLayout.jsx'
 import './App.css'
 
 export default function App() {
-  const token = localStorage.getItem('token')
-
   return (
-    <>
-      <AppBar position="static">
-        <Toolbar>
-          <Button color="inherit" component={Link} to="/">Home</Button>
-          <Button color="inherit" component={Link} to="/documents">Documents</Button>
-          <Button color="inherit" component={Link} to="/chat">Chat</Button>
-          {token && <Button color="inherit" component={Link} to="/admin">Admin</Button>}
-          <Button color="inherit" component={Link} to="/login">Login</Button>
-          <Button color="inherit" component={Link} to="/register">Register</Button>
-        </Toolbar>
-      </AppBar>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/documents" element={<Documents />} />
-        <Route path="/chat" element={<ChatPage />} />
-        <Route path="/admin" element={<AdminDashboard />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
-      </Routes>
-    </>
+    <Routes>
+      <Route path="/" element={<AppLayout />}> 
+        <Route index element={<Home />} />
+        <Route path="documents" element={<Documents />} />
+        <Route path="chat" element={<ChatPage />} />
+        <Route path="admin" element={<AdminDashboard />} />
+        <Route path="login" element={<Login />} />
+        <Route path="register" element={<Register />} />
+      </Route>
+    </Routes>
   )
 }

--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { Outlet, NavLink } from 'react-router-dom'
+import {
+  AppBar,
+  Toolbar,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Box,
+  Typography
+} from '@mui/material'
+import WorkspaceSelector from './WorkspaceSelector.jsx'
+
+const drawerWidth = 200
+
+export default function AppLayout() {
+  const [workspace, setWorkspace] = useState(null)
+
+  const pages = [
+    { name: 'Home', path: '/' },
+    { name: 'Documents', path: '/documents' },
+    { name: 'Chat', path: '/chat' },
+    { name: 'Admin', path: '/admin' },
+    { name: 'Login', path: '/login' },
+    { name: 'Register', path: '/register' }
+  ]
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <AppBar position="fixed" sx={{ zIndex: theme => theme.zIndex.drawer + 1 }}>
+        <Toolbar>
+          <WorkspaceSelector onChange={setWorkspace} />
+          {workspace && (
+            <Typography sx={{ ml: 2 }}>{workspace.name}</Typography>
+          )}
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box' }
+        }}
+      >
+        <Toolbar />
+        <List>
+          {pages.map(p => (
+            <ListItem key={p.path} disablePadding>
+              <ListItemButton
+                component={NavLink}
+                to={p.path}
+                end
+                sx={{ '&.active': { bgcolor: 'action.selected' } }}
+              >
+                <ListItemText primary={p.name} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+        <Toolbar />
+        <Outlet context={{ workspace }} />
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/components/WorkspaceSelector.jsx
+++ b/frontend/src/components/WorkspaceSelector.jsx
@@ -11,12 +11,14 @@ export default function WorkspaceSelector({ onChange }) {
   }, [])
 
   const handleChange = e => {
-    setValue(e.target.value)
-    if (onChange) onChange(e.target.value)
+    const id = e.target.value
+    setValue(id)
+    const ws = workspaces.find(w => w.id === id)
+    if (onChange) onChange(ws)
   }
 
   return (
-    <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+    <FormControl size="small" sx={{ minWidth: 150 }}>
       <InputLabel id="ws-label">Workspace</InputLabel>
       <Select labelId="ws-label" value={value} label="Workspace" onChange={handleChange}>
         {workspaces.map(ws => (

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -1,14 +1,16 @@
-import { useState } from 'react'
-import WorkspaceSelector from '../components/WorkspaceSelector.jsx'
+import { useOutletContext } from 'react-router-dom'
 import ChatView from '../components/ChatView.jsx'
-import { Container } from '@mui/material'
+import { Container, Typography } from '@mui/material'
 
 export default function ChatPage() {
-  const [ws, setWs] = useState(null)
+  const { workspace } = useOutletContext()
   return (
     <Container sx={{ mt: 2 }}>
-      <WorkspaceSelector onChange={setWs} />
-      {ws && <ChatView key={ws} />}
+      {workspace ? (
+        <ChatView key={workspace.id} />
+      ) : (
+        <Typography>Select a workspace</Typography>
+      )}
     </Container>
   )
 }


### PR DESCRIPTION
## Summary
- add `AppLayout` component with drawer navigation and workspace selector
- move workspace selector into top bar
- update `Chat` page to get the current workspace from layout
- wrap routes with layout

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687bffd2ab6483288bfaa25f6dc562e3