### PR TITLE
Add footer and placeholder pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,17 @@ Authentication for the admin interface uses HTTP basic auth. Update the OpenRout
 
 ### Environment Configuration
 
-Set `LINCHAT_ENV` to `development` or `production` to load the appropriate config. Database and vector store locations are controlled by `LINCHAT_DB_FILE` and `LINCHAT_VECTOR_DIR`. Logging is configured via `LOG_LEVEL` and `LOG_FILE`. For HTTPS deployments pass `--ssl-keyfile` and `--ssl-certfile` to `uvicorn` or use a reverse proxy.
+Set `LINCHAT_ENV` to `development` or `production` to load the appropriate config. Database and vector store locations are controlled by `LINCHAT_DB_FILE` and `LINCHAT_VECTOR_DIR`. Logging is configured via `LOG_LEVEL` and `LOG_FILE`.
+
+### HTTPS Setup
+
+To serve the API over HTTPS you can either place a reverse proxy such as Nginx or Traefik in front of Uvicorn or start Uvicorn with a certificate directly:
+
+```bash
+uvicorn app.main:app --ssl-keyfile /path/to/key.pem --ssl-certfile /path/to/cert.pem
+```
+
+When using a proxy, terminate TLS at the proxy and forward traffic to the backend on port `8000`.
 
 ### Authentication & Teams
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LinChat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <footer style="margin-top: 2rem; text-align: center;">
+      <a href="/privacy">Privacy Policy</a> |
+      <a href="/about">About</a> |
+      <a href="/contact">Contact</a>
+    </footer>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,9 @@ import { AppBar, Toolbar, Button } from '@mui/material'
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
 import ChatPage from './pages/Chat.jsx'
+import Privacy from './pages/Privacy.jsx'
+import About from './pages/About.jsx'
+import Contact from './pages/Contact.jsx'
 import Login from './Login.jsx'
 import Register from './Register.jsx'
 import AdminDashboard from './admin/AdminDashboard.jsx'
@@ -30,6 +33,9 @@ export default function App() {
         <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/privacy" element={<Privacy />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/contact" element={<Contact />} />
       </Routes>
     </>
   )

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <div>
+      <h2>About</h2>
+      <p>Information about this project will appear here.</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -1,0 +1,8 @@
+export default function Contact() {
+  return (
+    <div>
+      <h2>Contact</h2>
+      <p>Reach out to us through the channels listed here.</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/Privacy.jsx
+++ b/frontend/src/pages/Privacy.jsx
@@ -1,0 +1,8 @@
+export default function Privacy() {
+  return (
+    <div>
+      <h2>Privacy Policy</h2>
+      <p>This page will outline our privacy practices.</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add index footer with links to Privacy Policy, About and Contact
- create placeholder React pages for these sections
- route `/privacy`, `/about` and `/contact` to the new pages
- document HTTPS setup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bffdca6f083288195e2efa61140a3