### PR TITLE
Improve accessibility and responsive layout

### DIFF
--- a/frontend/src/admin/WorkspaceTable.jsx
+++ b/frontend/src/admin/WorkspaceTable.jsx
@@ -18,7 +18,11 @@ export default function WorkspaceTable({ workspaces, onDelete }) {
               <TableCell>{w.id}</TableCell>
               <TableCell>{w.name}</TableCell>
               <TableCell>
-                <IconButton size="small" onClick={() => onDelete(w.id)}>
+                <IconButton
+                  size="small"
+                  aria-label="delete workspace"
+                  onClick={() => onDelete(w.id)}
+                >
                   <DeleteIcon fontSize="small" />
                 </IconButton>
               </TableCell>

--- a/frontend/src/components/ChartUploader.jsx
+++ b/frontend/src/components/ChartUploader.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Button } from '@mui/material'
+import { Box, Button, Stack } from '@mui/material'
 import { analyzeFile } from '../api.js'
 
 export default function ChartUploader() {
@@ -21,12 +21,22 @@ export default function ChartUploader() {
 
   return (
     <Box>
-      <Box component="form" onSubmit={handleAnalyze} sx={{ mb: 2 }}>
-        <input type="file" onChange={e => setFile(e.target.files[0])} />
-        <Button type="submit" variant="contained" sx={{ ml: 1 }}>
+      <Stack
+        component="form"
+        onSubmit={handleAnalyze}
+        spacing={1}
+        direction={{ xs: 'column', sm: 'row' }}
+        sx={{ mb: 2 }}
+      >
+        <input
+          type="file"
+          aria-label="choose file for analysis"
+          onChange={e => setFile(e.target.files[0])}
+        />
+        <Button type="submit" variant="contained" aria-label="analyze file">
           Analyze
         </Button>
-      </Box>
+      </Stack>
       {chart && <img src={`data:image/png;base64,${chart}`} alt="chart" />}
       {stats && Array.isArray(stats) && (
         <pre>{JSON.stringify(stats, null, 2)}</pre>

--- a/frontend/src/components/ChatView.jsx
+++ b/frontend/src/components/ChatView.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Box, Button, TextField, Paper, Typography, Link } from '@mui/material'
+import { Box, Button, TextField, Paper, Typography, Link, Stack } from '@mui/material'
 import { createChatSession, queryLLM, exportPdf } from '../api.js'
 
 export default function ChatView() {
@@ -35,19 +35,39 @@ export default function ChatView() {
 
   return (
     <Box>
-      <Box component="form" onSubmit={handleSend} sx={{ mb: 2, display: 'flex', gap: 1 }}>
-        <TextField value={prompt} onChange={e => setPrompt(e.target.value)} fullWidth size="small" />
-        <Button type="submit" variant="contained">Send</Button>
-      </Box>
-      {messages.map((m, idx) => (
-        <Paper key={idx} sx={{ p: 1, mb: 1 }}>
-          <Typography variant="subtitle2" component="span">
-            {m.role === 'user' ? 'User:' : 'Assistant:'}
-          </Typography>{' '}
-          <span dangerouslySetInnerHTML={{ __html: m.content }} />
-        </Paper>
-      ))}
-      <Button variant="contained" onClick={handleExport} sx={{ mt: 2 }}>
+      <Stack
+        component="form"
+        onSubmit={handleSend}
+        spacing={1}
+        direction={{ xs: 'column', sm: 'row' }}
+        sx={{ mb: 2 }}
+      >
+        <TextField
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          fullWidth
+          size="small"
+        />
+        <Button type="submit" variant="contained" aria-label="send message">
+          Send
+        </Button>
+      </Stack>
+      <Stack role="log" spacing={1}>
+        {messages.map((m, idx) => (
+          <Paper key={idx} sx={{ p: 1 }}>
+            <Typography variant="subtitle2" component="span">
+              {m.role === 'user' ? 'User:' : 'Assistant:'}
+            </Typography>{' '}
+            <span dangerouslySetInnerHTML={{ __html: m.content }} />
+          </Paper>
+        ))}
+      </Stack>
+      <Button
+        variant="contained"
+        onClick={handleExport}
+        sx={{ mt: 2 }}
+        aria-label="export conversation as PDF"
+      >
         Export PDF
       </Button>
       {pdfUrl && (

--- a/frontend/src/components/ExportButtons.jsx
+++ b/frontend/src/components/ExportButtons.jsx
@@ -16,7 +16,7 @@ export default function ExportButtons({ content }) {
 
   return (
     <Box sx={{ mt: 2 }}>
-      <Button variant="contained" onClick={handlePdf}>
+      <Button variant="contained" onClick={handlePdf} aria-label="export PDF">
         Export PDF
       </Button>
       {url && (

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Button, Typography, Stack } from '@mui/material'
 import { uploadFile } from '../api.js'
 
 export default function FileUpload() {
@@ -18,14 +18,22 @@ export default function FileUpload() {
   }
 
   return (
-    <Box component="form" onSubmit={handleUpload} sx={{ mb: 2 }}>
-      <input type="file" onChange={e => setFile(e.target.files[0])} />
-      <Button type="submit" variant="contained" sx={{ ml: 1 }}>
+    <Stack
+      component="form"
+      onSubmit={handleUpload}
+      spacing={1}
+      direction={{ xs: 'column', sm: 'row' }}
+      sx={{ mb: 2 }}
+    >
+      <input
+        type="file"
+        aria-label="choose file"
+        onChange={e => setFile(e.target.files[0])}
+      />
+      <Button type="submit" variant="contained" aria-label="upload file">
         Upload
       </Button>
-      <Typography variant="body2" sx={{ ml: 1 }}>
-        {status}
-      </Typography>
-    </Box>
+      <Typography variant="body2">{status}</Typography>
+    </Stack>
   )
 }

--- a/frontend/src/components/QueryForm.jsx
+++ b/frontend/src/components/QueryForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Button, TextField, Paper, Typography } from '@mui/material'
+import { Box, Button, TextField, Paper, Typography, Stack } from '@mui/material'
 import { queryLLM, getCitation } from '../api.js'
 
 export default function QueryForm({ onAnswer }) {
@@ -45,10 +45,12 @@ export default function QueryForm({ onAnswer }) {
 
   return (
     <Box>
-      <Box
+      <Stack
         component="form"
         onSubmit={handleSubmit}
-        sx={{ mb: 2, display: 'flex', gap: 1 }}
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={1}
+        sx={{ mb: 2 }}
       >
         <TextField
           value={prompt}
@@ -57,10 +59,10 @@ export default function QueryForm({ onAnswer }) {
           fullWidth
           size="small"
         />
-        <Button type="submit" variant="contained">
+        <Button type="submit" variant="contained" aria-label="send query">
           Send
         </Button>
-      </Box>
+      </Stack>
       {renderAnswer()}
       {citation && (
         <Paper sx={{ p: 1, mt: 2 }}>

--- a/frontend/src/components/TableGenerator.jsx
+++ b/frontend/src/components/TableGenerator.jsx
@@ -10,6 +10,7 @@ import {
   TableHead,
   TableRow,
   Paper,
+  Stack,
 } from '@mui/material'
 import { generateTable } from '../api.js'
 
@@ -56,15 +57,23 @@ export default function TableGenerator() {
 
   return (
     <Box>
-      <Box component="form" onSubmit={handleGen} sx={{ mb: 2, display: 'flex', gap: 1 }}>
+      <Stack
+        component="form"
+        onSubmit={handleGen}
+        spacing={1}
+        direction={{ xs: 'column', sm: 'row' }}
+        sx={{ mb: 2 }}
+      >
         <TextField
           value={prompt}
           onChange={e => setPrompt(e.target.value)}
           placeholder="Table prompt"
           size="small"
         />
-        <Button type="submit" variant="contained">Generate Table</Button>
-      </Box>
+        <Button type="submit" variant="contained" aria-label="generate table">
+          Generate Table
+        </Button>
+      </Stack>
       {renderTable()}
     </Box>
   )

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -1,14 +1,16 @@
 import { useState } from 'react'
 import WorkspaceSelector from '../components/WorkspaceSelector.jsx'
 import ChatView from '../components/ChatView.jsx'
-import { Container } from '@mui/material'
+import { Container, Stack } from '@mui/material'
 
 export default function ChatPage() {
   const [ws, setWs] = useState(null)
   return (
     <Container sx={{ mt: 2 }}>
-      <WorkspaceSelector onChange={setWs} />
-      {ws && <ChatView key={ws} />}
+      <Stack spacing={2}>
+        <WorkspaceSelector onChange={setWs} />
+        {ws && <ChatView key={ws} />}
+      </Stack>
     </Container>
   )
 }

--- a/frontend/src/pages/Documents.jsx
+++ b/frontend/src/pages/Documents.jsx
@@ -1,10 +1,20 @@
 import { useEffect, useState } from 'react'
-import { Box, Button } from '@mui/material'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Stack,
+} from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
 import { getDocuments, deleteDocument, setShared } from '../api.js'
 
 export default function Documents() {
   const [docs, setDocs] = useState([])
+  const [deleteId, setDeleteId] = useState(null)
 
   useEffect(() => {
     load()
@@ -19,10 +29,15 @@ export default function Documents() {
     }
   }
 
-  async function handleDelete(id) {
-    if (!confirm('Delete document?')) return
-    await deleteDocument(id)
-    setDocs(docs.filter(d => d.id !== id))
+  async function confirmDelete() {
+    if (!deleteId) return
+    await deleteDocument(deleteId)
+    setDocs(docs.filter(d => d.id !== deleteId))
+    setDeleteId(null)
+  }
+
+  const handleDelete = id => {
+    setDeleteId(id)
   }
 
   async function handleToggle(id, shared) {
@@ -58,7 +73,7 @@ export default function Documents() {
   ]
 
   return (
-    <Box>
+    <Stack spacing={2}>
       <h2>Documents</h2>
       <DataGrid
         autoHeight
@@ -67,6 +82,24 @@ export default function Documents() {
         disableRowSelectionOnClick
         density="compact"
       />
-    </Box>
+      <Dialog
+        open={deleteId !== null}
+        onClose={() => setDeleteId(null)}
+        aria-labelledby="confirm-delete-title"
+      >
+        <DialogTitle id="confirm-delete-title">Delete Document</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete this document?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteId(null)}>Cancel</Button>
+          <Button onClick={confirmDelete} autoFocus aria-label="confirm delete">
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
   )
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,18 +4,19 @@ import TableGenerator from '../components/TableGenerator.jsx'
 import ChartUploader from '../components/ChartUploader.jsx'
 import ExportButtons from '../components/ExportButtons.jsx'
 import { useState } from 'react'
+import { Stack } from '@mui/material'
 
 export default function Home() {
   const [lastAnswer, setLastAnswer] = useState('')
 
   return (
-    <div>
+    <Stack spacing={2}>
       <h1>LinChat Frontend</h1>
       <FileUpload />
       <QueryForm onAnswer={setLastAnswer} />
       <TableGenerator />
       <ChartUploader />
       <ExportButtons content={lastAnswer} />
-    </div>
+    </Stack>
   )
 }


### PR DESCRIPTION
## Summary
- add ARIA labels and roles to interactive elements
- refactor forms and pages to use responsive Stack layout
- switch delete confirmation in documents page to accessible dialog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bffddd1488328b508e0ce4d6fb6f5