### PR TITLE
Add workspace management page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -303,7 +303,9 @@ async def admin_data(auth: bool = Depends(_require_admin)):
     return {
         "has_key": has_key,
         "model": model,
-        "users": [{"id": u.id, "email": u.email} for u in users],
+        "users": [
+            {"id": u.id, "email": u.email, "team_id": u.team_id} for u in users
+        ],
         "workspaces": [{"id": t.id, "name": t.name} for t in teams],
         "logs": [
             {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { AppBar, Toolbar, Button } from '@mui/material'
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
 import ChatPage from './pages/Chat.jsx'
+import WorkspacePage from './pages/Workspace.jsx'
 import Login from './Login.jsx'
 import Register from './Register.jsx'
 import AdminDashboard from './admin/AdminDashboard.jsx'
@@ -18,6 +19,7 @@ export default function App() {
           <Button color="inherit" component={Link} to="/">Home</Button>
           <Button color="inherit" component={Link} to="/documents">Documents</Button>
           <Button color="inherit" component={Link} to="/chat">Chat</Button>
+          <Button color="inherit" component={Link} to="/workspace">Workspace</Button>
           {token && <Button color="inherit" component={Link} to="/admin">Admin</Button>}
           <Button color="inherit" component={Link} to="/login">Login</Button>
           <Button color="inherit" component={Link} to="/register">Register</Button>
@@ -27,6 +29,7 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/documents" element={<Documents />} />
         <Route path="/chat" element={<ChatPage />} />
+        <Route path="/workspace" element={<WorkspacePage />} />
         <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -153,3 +153,14 @@ export async function deleteWorkspace(id) {
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
+
+export async function assignWorkspace(userId, teamId) {
+  const form = new FormData();
+  form.append('team_id', teamId);
+  const res = await fetch(`${API_BASE}/users/${userId}/workspace`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}

--- a/frontend/src/pages/Workspace.jsx
+++ b/frontend/src/pages/Workspace.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import { Container, Box, TextField, Button, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material'
+import WorkspaceSelector from '../components/WorkspaceSelector.jsx'
+import AuditLogTable from '../admin/AuditLogTable.jsx'
+import { getAdminData, inviteUser, assignWorkspace } from '../api.js'
+
+export default function WorkspacePage() {
+  const [data, setData] = useState({ users: [], workspaces: [], logs: [] })
+  const [workspace, setWorkspace] = useState(null)
+  const [inviteEmail, setInviteEmail] = useState('')
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  async function load() {
+    const d = await getAdminData()
+    setData(d)
+  }
+
+  async function handleInvite(e) {
+    e.preventDefault()
+    if (!workspace) return
+    const res = await inviteUser(inviteEmail, workspace)
+    alert(`Password: ${res.password}`)
+    setInviteEmail('')
+    load()
+  }
+
+  async function handleAssign(userId, teamId) {
+    await assignWorkspace(userId, teamId)
+    load()
+  }
+
+  const members = data.users.filter(u => u.team_id === workspace)
+
+  return (
+    <Container sx={{ mt: 2 }}>
+      <Typography variant="h5" sx={{ mb: 2 }}>Workspace</Typography>
+      <WorkspaceSelector onChange={setWorkspace} />
+      {workspace && (
+        <>
+          <Box component="form" onSubmit={handleInvite} sx={{ display: 'flex', gap: 1, mb: 2 }}>
+            <TextField label="Invite Email" value={inviteEmail} onChange={e => setInviteEmail(e.target.value)} size="small" />
+            <Button type="submit" variant="contained">Invite</Button>
+          </Box>
+          <Typography variant="h6">Members</Typography>
+          <TableContainer component={Paper} sx={{ mb: 2 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Email</TableCell>
+                  <TableCell>Workspace</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {members.map(m => (
+                  <TableRow key={m.id}>
+                    <TableCell>{m.email}</TableCell>
+                    <TableCell>
+                      <select value={m.team_id || ''} onChange={e => handleAssign(m.id, e.target.value)}>
+                        <option value="">None</option>
+                        {data.workspaces.map(ws => (
+                          <option key={ws.id} value={ws.id}>{ws.name}</option>
+                        ))}
+                      </select>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <Typography variant="h6">Activity</Typography>
+          <AuditLogTable logs={data.logs} />
+        </>
+      )}
+    </Container>
+  )
+}


### PR DESCRIPTION
## Summary
- extend `/admin/data` to include `team_id` for users
- add API helper to assign users to workspaces
- create new `Workspace` page showing members, invitations and activity log
- link new page in navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bffddf72483288a52a98e884b007d