### PR TITLE
Add PDF export and sharing options

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { AppBar, Toolbar, Button } from '@mui/material'
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
 import ChatPage from './pages/Chat.jsx'
+import WorkspacePage from './pages/Workspace.jsx'
 import Login from './Login.jsx'
 import Register from './Register.jsx'
 import AdminDashboard from './admin/AdminDashboard.jsx'
@@ -17,6 +18,7 @@ export default function App() {
         <Toolbar>
           <Button color="inherit" component={Link} to="/">Home</Button>
           <Button color="inherit" component={Link} to="/documents">Documents</Button>
+          <Button color="inherit" component={Link} to="/workspaces">Workspaces</Button>
           <Button color="inherit" component={Link} to="/chat">Chat</Button>
           {token && <Button color="inherit" component={Link} to="/admin">Admin</Button>}
           <Button color="inherit" component={Link} to="/login">Login</Button>
@@ -26,6 +28,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/documents" element={<Documents />} />
+        <Route path="/workspaces" element={<WorkspacePage />} />
         <Route path="/chat" element={<ChatPage />} />
         <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/login" element={<Login />} />

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
 export async function queryLLM(prompt, sessionId) {
   const res = await fetch(`${API_BASE}/query`, {

--- a/frontend/src/components/ChatView.jsx
+++ b/frontend/src/components/ChatView.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Box, Button, TextField, Paper, Typography, Link } from '@mui/material'
-import { createChatSession, queryLLM, exportPdf } from '../api.js'
+import { API_BASE, createChatSession, queryLLM, exportPdf } from '../api.js'
 
 export default function ChatView() {
   const [sessionId, setSessionId] = useState(null)
@@ -30,6 +30,12 @@ export default function ChatView() {
       .map(m => `**${m.role === 'user' ? 'User' : 'Assistant'}:** ${m.content}`)
       .join('\n\n')
     const link = await exportPdf(text)
+    const a = document.createElement('a')
+    a.href = link
+    a.download = 'chat.pdf'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
     setPdfUrl(link)
   }
 
@@ -49,6 +55,14 @@ export default function ChatView() {
       ))}
       <Button variant="contained" onClick={handleExport} sx={{ mt: 2 }}>
         Export PDF
+      </Button>
+      <Button
+        variant="outlined"
+        href={`${API_BASE}/chat/${sessionId}/export/pdf`}
+        target="_blank"
+        sx={{ mt: 2, ml: 1 }}
+      >
+        Share Transcript
       </Button>
       {pdfUrl && (
         <Link href={pdfUrl} download="chat.pdf" sx={{ ml: 1 }}>

--- a/frontend/src/pages/Documents.jsx
+++ b/frontend/src/pages/Documents.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Box, Button } from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
-import { getDocuments, deleteDocument, setShared } from '../api.js'
+import { API_BASE, getDocuments, deleteDocument, setShared } from '../api.js'
 
 export default function Documents() {
   const [docs, setDocs] = useState([])
@@ -42,7 +42,7 @@ export default function Documents() {
     {
       field: 'actions',
       headerName: 'Actions',
-      width: 180,
+      width: 240,
       sortable: false,
       renderCell: params => (
         <Box sx={{ display: 'flex', gap: 1 }}>
@@ -51,6 +51,9 @@ export default function Documents() {
           </Button>
           <Button size="small" onClick={() => handleToggle(params.row.id, params.row.is_shared)}>
             {params.row.is_shared ? 'Unshare' : 'Share'}
+          </Button>
+          <Button size="small" onClick={() => navigator.clipboard.writeText(`${API_BASE}/documents/${params.row.id}`)}>
+            Copy Link
           </Button>
         </Box>
       ),

--- a/frontend/src/pages/Workspace.jsx
+++ b/frontend/src/pages/Workspace.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { Box, Button, List, ListItem, ListItemText } from '@mui/material'
+import { API_BASE, getWorkspaces } from '../api.js'
+
+export default function WorkspacePage() {
+  const [workspaces, setWorkspaces] = useState([])
+
+  useEffect(() => {
+    getWorkspaces().then(res => setWorkspaces(res.workspaces || []))
+  }, [])
+
+  const handleCopy = id => {
+    navigator.clipboard.writeText(`${window.location.origin}/workspace/${id}`)
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <h2>Workspaces</h2>
+      <List>
+        {workspaces.map(ws => (
+          <ListItem
+            key={ws.id}
+            secondaryAction={
+              <Button size="small" onClick={() => handleCopy(ws.id)}>
+                Copy Link
+              </Button>
+            }
+          >
+            <ListItemText primary={ws.name} />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- improve `ChatView` to auto-download PDFs and share transcripts
- allow copying document links in `Documents` page
- add a simple Workspace listing page with share links
- expose `API_BASE` constant for reuse
- register new page in router

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bffdef9b08328b2e3f4563bc74cca