### PR TITLE
Add condensed TOC and onboarding component

### DIFF
--- a/docs/oshan_toc.md
+++ b/docs/oshan_toc.md
@@ -1,0 +1,16 @@
+# Oshan Equity Insights - Condensed TOC
+
+1. Vision & Philosophy
+2. Product Overview
+3. Brand & UX Direction
+4. Wireframes
+5. Tech Stack
+6. System Architecture
+7. Component-Level Design
+8. Data Management
+9. Environment Variables
+10. Agile Epics
+11. Security & Compliance
+12. CI/CD & Automation
+13. Contributor Guide
+14. Appendices

--- a/frontend/src/components/OnboardingScreen.jsx
+++ b/frontend/src/components/OnboardingScreen.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+import { View, Text, TouchableOpacity } from 'react-native'
+
+const questions = [
+  {
+    id: 'style',
+    text: "What's your investing style?",
+    options: ['Value Hunter', 'Momentum', 'Long-Term', 'Speculator'],
+  },
+  {
+    id: 'sector',
+    text: 'Preferred sectors?',
+    options: ['Tech', 'Finance', 'Energy', 'Healthcare'],
+  },
+  {
+    id: 'risk',
+    text: 'Risk tolerance?',
+    options: ['Low', 'Medium', 'High', 'Very High'],
+  },
+  {
+    id: 'experience',
+    text: 'Experience level?',
+    options: ['Beginner', 'Intermediate', 'Advanced', 'Expert'],
+  },
+]
+
+export default function OnboardingScreen({ onComplete }) {
+  const [answers, setAnswers] = useState({})
+  const handleSelect = (qid, option) => {
+    setAnswers(prev => ({ ...prev, [qid]: option }))
+  }
+  const allAnswered = questions.every(q => answers[q.id])
+
+  return (
+    <View>
+      {questions.map(q => (
+        <View key={q.id}>
+          <Text>{q.text}</Text>
+          {q.options.map(option => (
+            <TouchableOpacity
+              key={option}
+              onPress={() => handleSelect(q.id, option)}
+            >
+              <Text>
+                {answers[q.id] === option ? '🔘' : '⚪'} {option}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      ))}
+      {allAnswered && (
+        <TouchableOpacity onPress={() => onComplete?.(answers)}>
+          <Text>Finish</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- add a short Table of Contents for the Oshan doc
- include a simple React Native onboarding screen example

## Testing
- `pytest -q tests/test_admin_workspaces.py 2>&1 | head -n 20` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687c006fcf288328b812d0838b81d5a6