### PR TITLE
Apply premium branding and update auth UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;700&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import logo from './assets/logo.svg'
 import AppLayout from './components/AppLayout.jsx'
 import Onboarding from './components/Onboarding.jsx'
 import PersistentChat from './components/PersistentChat.jsx'
+import Footer from './components/Footer.jsx'
 
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
@@ -67,6 +68,8 @@ export default function App() {
 
         <PersistentChat />
       </Box>
+
+      <Footer />
 
       <Onboarding open={showOnboarding} onClose={handleCloseOnboarding} />
     </>

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,36 +1,83 @@
 import { useState } from 'react'
-import { Box, TextField, Button, Typography } from '@mui/material'
+import {
+  Box,
+  TextField,
+  Button,
+  Typography,
+  Container,
+  Paper,
+  Stack,
+  Link,
+} from '@mui/material'
 import { loginUser } from './api.js'
-import { useNavigate } from 'react-router-dom'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+import logo from './assets/logo.svg'
 
 export default function Login() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [errors, setErrors] = useState({})
   const navigate = useNavigate()
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    const fieldErrors = {}
+    if (!username) fieldErrors.username = 'Username required'
+    if (!password) fieldErrors.password = 'Password required'
+    setErrors(fieldErrors)
+    if (Object.keys(fieldErrors).length > 0) return
     try {
       const data = await loginUser(username, password)
       if (data.access_token) {
         localStorage.setItem('token', data.access_token)
-        // trigger onboarding on first login
         if (!localStorage.getItem('onboardingSeen')) {
           localStorage.setItem('showOnboarding', 'true')
         }
       }
       navigate('/')
     } catch (err) {
-      alert(err.message)
+      setErrors({ password: err.message })
     }
   }
 
   return (
-    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, mx: 'auto', maxWidth: 400, display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Typography variant="h5">Login</Typography>
-      <TextField label="Username" value={username} onChange={e => setUsername(e.target.value)} required />
-      <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
-      <Button type="submit" variant="contained">Login</Button>
-    </Box>
+    <Container maxWidth="sm" sx={{ mt: 4 }}>
+      <Paper sx={{ p: 4 }}>
+        <Stack spacing={2} component="form" onSubmit={handleSubmit}>
+          <Box sx={{ textAlign: 'center' }}>
+            <Box component="img" src={logo} alt="LinChat" sx={{ height: 48, mb: 1 }} />
+            <Typography variant="h5">Login to LinChat</Typography>
+          </Box>
+          <TextField
+            label="Username"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            error={Boolean(errors.username)}
+            helperText={errors.username}
+            required
+          />
+          <TextField
+            label="Password"
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            error={Boolean(errors.password)}
+            helperText={errors.password}
+            required
+          />
+          <Button type="submit" variant="contained" sx={{ width: { xs: '100%', sm: '50%' }, alignSelf: 'center' }}>
+            Login
+          </Button>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Link component={RouterLink} to="/forgot-password" underline="hover">
+              Forgot password?
+            </Link>
+            <Link component={RouterLink} to="/register" underline="hover">
+              Create an account
+            </Link>
+          </Box>
+        </Stack>
+      </Paper>
+    </Container>
   )
 }

--- a/frontend/src/Register.jsx
+++ b/frontend/src/Register.jsx
@@ -1,31 +1,85 @@
 import { useState } from 'react'
-import { Box, TextField, Button, Typography } from '@mui/material'
+import {
+  Box,
+  TextField,
+  Button,
+  Typography,
+  Container,
+  Paper,
+  Stack,
+  Link,
+} from '@mui/material'
 import { registerUser } from './api.js'
-import { useNavigate } from 'react-router-dom'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+import logo from './assets/logo.svg'
 
 export default function Register() {
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [errors, setErrors] = useState({})
   const navigate = useNavigate()
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    const fieldErrors = {}
+    if (!username) fieldErrors.username = 'Username required'
+    if (!email) fieldErrors.email = 'Email required'
+    if (!password) fieldErrors.password = 'Password required'
+    setErrors(fieldErrors)
+    if (Object.keys(fieldErrors).length > 0) return
     try {
       await registerUser({ username, email, password })
       navigate('/login')
     } catch (err) {
-      alert(err.message)
+      setErrors({ password: err.message })
     }
   }
 
   return (
-    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, mx: 'auto', maxWidth: 400, display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Typography variant="h5">Register</Typography>
-      <TextField label="Username" value={username} onChange={e => setUsername(e.target.value)} required />
-      <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
-      <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
-      <Button type="submit" variant="contained">Register</Button>
-    </Box>
+    <Container maxWidth="sm" sx={{ mt: 4 }}>
+      <Paper sx={{ p: 4 }}>
+        <Stack spacing={2} component="form" onSubmit={handleSubmit}>
+          <Box sx={{ textAlign: 'center' }}>
+            <Box component="img" src={logo} alt="LinChat" sx={{ height: 48, mb: 1 }} />
+            <Typography variant="h5">Create an Account</Typography>
+          </Box>
+          <TextField
+            label="Username"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            error={Boolean(errors.username)}
+            helperText={errors.username}
+            required
+          />
+          <TextField
+            label="Email"
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            error={Boolean(errors.email)}
+            helperText={errors.email}
+            required
+          />
+          <TextField
+            label="Password"
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            error={Boolean(errors.password)}
+            helperText={errors.password}
+            required
+          />
+          <Button type="submit" variant="contained" sx={{ width: { xs: '100%', sm: '50%' }, alignSelf: 'center' }}>
+            Register
+          </Button>
+          <Box sx={{ textAlign: 'center' }}>
+            <Link component={RouterLink} to="/login" underline="hover">
+              Already have an account? Login
+            </Link>
+          </Box>
+        </Stack>
+      </Paper>
+    </Container>
   )
 }

--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="48" fill="#1976d2"/>
+  <circle cx="50" cy="50" r="48" fill="#0d47a1"/>
   <text x="50%" y="55%" text-anchor="middle" font-size="40" fill="#fff" font-family="Arial, sans-serif">LC</text>
 </svg>

--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -12,6 +12,8 @@ import {
   Typography
 } from '@mui/material'
 import WorkspaceSelector from './WorkspaceSelector.jsx'
+import Footer from './Footer.jsx'
+import logo from '../assets/logo.svg'
 
 const drawerWidth = 200
 
@@ -45,7 +47,9 @@ export default function AppLayout() {
           '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box' }
         }}
       >
-        <Toolbar />
+        <Toolbar>
+          <Box component="img" src={logo} alt="LinChat" sx={{ height: 32 }} />
+        </Toolbar>
         <List>
           {pages.map(p => (
             <ListItem key={p.path} disablePadding>
@@ -64,6 +68,7 @@ export default function AppLayout() {
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
         <Outlet context={{ workspace }} />
+        <Footer />
       </Box>
     </Box>
   )

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,24 @@
+import { Box, Link, Stack } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+import logo from '../assets/logo.svg'
+
+export default function Footer() {
+  return (
+    <Box component="footer" sx={{ mt: 4, py: 2, textAlign: 'center', borderTop: 1, borderColor: 'divider' }}>
+      <Stack spacing={1} alignItems="center">
+        <Box component="img" src={logo} alt="LinChat" sx={{ height: 32 }} />
+        <Stack direction="row" spacing={2}>
+          <Link component={RouterLink} to="/about" underline="hover">
+            About
+          </Link>
+          <Link component={RouterLink} to="/contact" underline="hover">
+            Contact
+          </Link>
+          <Link component={RouterLink} to="/privacy" underline="hover">
+            Privacy
+          </Link>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -3,16 +3,16 @@ import { createTheme } from '@mui/material/styles'
 const theme = createTheme({
   palette: {
     primary: {
-      main: '#1976d2',
-      light: '#42a5f5',
-      dark: '#1565c0',
+      main: '#0d47a1',
+      light: '#5472d3',
+      dark: '#002171',
     },
     secondary: {
-      main: '#ff4081',
+      main: '#ffd700',
     },
   },
   typography: {
-    fontFamily: '"Open Sans", Arial, sans-serif',
+    fontFamily: '"Poppins", "Helvetica Neue", Arial, sans-serif',
     h1: {
       fontSize: '2rem',
       fontWeight: 700,


### PR DESCRIPTION
## Summary
- update primary color palette and fonts in MUI theme
- load Poppins font in `index.html`
- redesign Login and Register pages per wireframes
- add brand logo and footer with About/Contact/Privacy links
- update drawer layout to display brand logo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1c77f4248328a26081e6e4361843