### PR TITLE
Improve login onboarding

### DIFF
--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -32,6 +32,8 @@ export default function Login() {
         localStorage.setItem('token', data.access_token)
         if (!localStorage.getItem('onboardingSeen')) {
           localStorage.setItem('showOnboarding', 'true')
+        } else {
+          localStorage.setItem('showOnboarding', 'false')
         }
       }
       navigate('/')

--- a/frontend/src/components/Onboarding.jsx
+++ b/frontend/src/components/Onboarding.jsx
@@ -57,6 +57,23 @@ export default function Onboarding({ open, onClose }) {
       ),
     },
     {
+      label: 'Manage Workspaces',
+      content: (
+        <Box sx={{ textAlign: 'center' }}>
+          <Typography sx={{ mb: 2 }}>
+            Create a workspace to collaborate with your team.
+          </Typography>
+          <Tooltip title="Visit the Workspace page to get started">
+            <span>
+              <Button variant="contained" disabled>
+                New Workspace
+              </Button>
+            </span>
+          </Tooltip>
+        </Box>
+      ),
+    },
+    {
       label: 'Export Results',
       content: (
         <Box sx={{ textAlign: 'center' }}>


### PR DESCRIPTION
## Summary
- trigger onboarding only the first time a user logs in
- expand onboarding with a workspace management step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3839d9688328b5b4f716a6cbbe96