### PR TITLE
Enable drag/drop chat uploads with progress

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -61,6 +61,24 @@ export async function analyzeFile(file, onProgress) {
   }
 }
 
+export async function analysisResults(file, onProgress) {
+  const form = new FormData();
+  form.append('file', file);
+  try {
+    const res = await axios.post(`${API_BASE}/analysis/results`, form, {
+      onUploadProgress: e => {
+        if (onProgress && e.total) {
+          onProgress(Math.round((e.loaded * 100) / e.total));
+        }
+      }
+    });
+    return res.data;
+  } catch (err) {
+    const msg = err.response?.data?.detail || err.message;
+    throw new Error(msg);
+  }
+}
+
 export async function getCitation(reqId, cid) {
   const res = await fetch(`${API_BASE}/source/${reqId}/${cid}`);
   if (!res.ok) throw new Error(await res.text());

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -140,3 +140,25 @@ def test_analysis_llm(monkeypatch, tmp_path):
     assert j["data"] == [{"col": "A", "mean": 1}]
     assert j["chart"] == "img"
 
+
+def test_analysis_results(monkeypatch, tmp_path):
+    main.logger = types.SimpleNamespace(info=lambda *a, **k: None)
+    monkeypatch.setattr(main, "add_audit_log", lambda *a, **k: None)
+
+    async def fake_analyze(path):
+        return [{"col": "B", "sum": 2}], "png"
+
+    monkeypatch.setattr(main, "analyze_file", fake_analyze)
+
+    client = TestClient(main.app)
+    main.app.dependency_overrides[main.current_active_user] = lambda: User()
+    f = tmp_path / "y.xlsx"
+    f.write_text("y")
+    with open(f, "rb") as fh:
+        resp = client.post(
+            "/analysis/results",
+            files={"file": ("y.xlsx", fh, "application/octet-stream")},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"data": [{"col": "B", "sum": 2}], "chart": "png"}
+


### PR DESCRIPTION
## Summary
- add `/analysis/results` endpoint to call the Rust service and strip code
- expose `analysisResults()` helper on the frontend
- integrate progress bar uploads in `ChatView`
- test new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3ae27288832893f29d9c87cf29cd