### PR TITLE
Fix frontend Docker build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,6 @@
   "service": "backend",
   "runServices": ["backend", "analysis", "frontend"],
   "workspaceFolder": "/workspace/LinChat",
-  "postCreateCommand": "pip install -r requirements.txt && cd frontend && npm ci",
+  "postCreateCommand": "pip install -r requirements.txt && cd frontend && npm ci --legacy-peer-deps",
   "forwardPorts": [8080, 8002, 8001]
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 ARG VITE_API_URL
 ENV VITE_API_URL=${VITE_API_URL}
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- run npm with `--legacy-peer-deps` during Docker build
- apply same flag in devcontainer setup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8254f9dc83289a619033de6d759d