### PR TITLE
Fix Chat page import reference

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import Footer from './components/Footer.jsx'
 
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
+// Route used to mistakenly import from "ChatPage.jsx"; ensure path matches filename
 import ChatPage from './pages/Chat.jsx'
 import AdminDashboard from './admin/AdminDashboard.jsx'
 import Login from './Login.jsx'


### PR DESCRIPTION
## Summary
- document correct Chat page path in `frontend/src/App.jsx`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4e56633883289e00af4a646d7c22