### PR TITLE
Fix chat page import path

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,6 @@ import Footer from './components/Footer.jsx'
 
 import Home from './pages/Home.jsx'
 import Documents from './pages/Documents.jsx'
-// Route used to mistakenly import from "ChatPage.jsx"; ensure path matches filename
 import ChatPage from './pages/Chat.jsx'
 import AdminDashboard from './admin/AdminDashboard.jsx'
 import Login from './Login.jsx'


### PR DESCRIPTION
## Summary
- clean up outdated comment in `App.jsx` now that ChatPage import path is correct

## Testing
- `npm ci --legacy-peer-deps`
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687f6683dd3c83289f31ba428d934eb9