### PR TITLE
Switch to API-based embeddings and add client test

### DIFF
--- a/pytest_asyncio.py
+++ b/pytest_asyncio.py
@@ -8,5 +8,5 @@ def pytest_configure(config):
 def pytest_pyfunc_call(pyfuncitem):
     if pyfuncitem.get_closest_marker("asyncio"):
         func = pyfuncitem.obj
-        asyncio.get_event_loop().run_until_complete(func(**pyfuncitem.funcargs))
+        asyncio.run(func(**pyfuncitem.funcargs))
         return True

--- a/tests/stubs/fastapi/testclient.py
+++ b/tests/stubs/fastapi/testclient.py
@@ -24,7 +24,7 @@ class TestClient:
                 dep_fn = self.app.dependency_overrides.get(param.default.dependency, param.default.dependency)
                 val = dep_fn()
                 if asyncio.iscoroutine(val):
-                    val = asyncio.get_event_loop().run_until_complete(val)
+                    val = asyncio.run(val)
                 kwargs[name] = val
             elif files and name == 'file':
                 file_tuple = files['file']
@@ -35,7 +35,7 @@ class TestClient:
                 kwargs[name] = data[name]
         result = handler(**kwargs)
         if asyncio.iscoroutine(result):
-            result = asyncio.get_event_loop().run_until_complete(result)
+            result = asyncio.run(result)
         status = 200
         if isinstance(result, dict):
             data = result

--- a/tests/test_analysis_service_client.py
+++ b/tests/test_analysis_service_client.py
@@ -1,0 +1,36 @@
+import types
+import asyncio
+import pytest
+
+import app.analysis_service_client as client
+
+class DummyResponse:
+    def __init__(self):
+        self.headers = {"Chart": "img"}
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return [{"col": "A"}]
+
+class DummyClient:
+    def __init__(self, called):
+        self.called = called
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def post(self, url, files=None):
+        self.called["url"] = url
+        self.called["filename"] = list(files.values())[0].name
+        return DummyResponse()
+
+def test_analyze_file(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(client, "httpx", types.SimpleNamespace(AsyncClient=lambda: DummyClient(called)))
+    f = tmp_path / "x.txt"
+    f.write_text("data")
+    data, chart = asyncio.run(client.analyze_file(str(f)))
+    assert data == [{"col": "A"}]
+    assert chart == "img"
+    assert called["url"].endswith("/analysis")
+    assert called["filename"].endswith("x.txt")

--- a/tests/test_vector_db.py
+++ b/tests/test_vector_db.py
@@ -3,17 +3,12 @@ import types
 
 sys.modules.setdefault('chromadb', types.SimpleNamespace(PersistentClient=object))
 sys.modules.setdefault('chromadb.config', types.SimpleNamespace(Settings=object))
-sys.modules.setdefault('sentence_transformers', types.SimpleNamespace(SentenceTransformer=lambda x: None))
+
 
 from app import vector_db
 
-class DummyModel:
-    class Emb(list):
-        def tolist(self):
-            return list(self)
-
-    def encode(self, texts):
-        return self.Emb([[len(t)] for t in texts])
+def dummy_embed(texts):
+    return [[len(t)] for t in texts]
 
 class DummyCollection:
     def __init__(self):
@@ -33,7 +28,7 @@ class DummyCollection:
 def test_add_and_query(monkeypatch):
     collection = DummyCollection()
     monkeypatch.setattr(vector_db, "_get_collection", lambda: collection)
-    monkeypatch.setattr(vector_db, "_get_model", lambda: DummyModel())
+    monkeypatch.setattr(vector_db, "_embed", dummy_embed)
 
     vector_db.add_embeddings(1, [{"page": 1, "text": "hello"}], workspace_id=1)
     res = vector_db.query("hello", top_k=1, workspace_id=1)
@@ -43,7 +38,7 @@ def test_add_and_query(monkeypatch):
 def test_add_web_embeddings(monkeypatch):
     collection = DummyCollection()
     monkeypatch.setattr(vector_db, "_get_collection", lambda: collection)
-    monkeypatch.setattr(vector_db, "_get_model", lambda: DummyModel())
+    monkeypatch.setattr(vector_db, "_embed", dummy_embed)
 
     vector_db.add_web_embeddings("http://example.com", "web text", workspace_id=2)
     res = vector_db.query("web", top_k=1, workspace_id=2)


### PR DESCRIPTION
## Summary
- remove local `SentenceTransformer` usage and rely on OpenRouter embeddings
- adjust pytest async helper to use `asyncio.run`
- update FastAPI test client stub to run coroutines with `asyncio.run`
- update vector DB tests for new `_embed` helper
- add new tests for `analysis_service_client`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9d069cec83289b4d0c6141f90818