### PR TITLE
Reduce Docker build size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \
-    playwright install --with-deps && \
+    playwright install --with-deps chromium && \
     rm -rf /root/.cache/pip
 
 COPY app ./app

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 ENV PYTHONPATH=/install/lib/python3.11/site-packages
 # Add the installation prefix to PATH so the Playwright CLI is available
 ENV PATH="/install/bin:$PATH"
-RUN playwright install --with-deps
+RUN playwright install --with-deps chromium
 
 # Rust toolchain for runtime compilation
 FROM rust:slim AS rust

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS build
+FROM node:20-alpine AS build
 WORKDIR /app
 ARG VITE_API_URL
 ENV VITE_API_URL=${VITE_API_URL}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ python-docx
 openpyxl
 python-pptx
 chromadb
-sentence-transformers
 playwright
 beautifulsoup4
 httpx


### PR DESCRIPTION
## Summary
- slim down Playwright install to only fetch the Chromium browser
- use a smaller Node base image for the frontend
- remove the unused sentence-transformers package from requirements

## Testing
- `pip install fastapi uvicorn httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fa0bdc5ac8328b9ee41c4ab3f4431