### PR TITLE
Fix flake8 lint issue in vector_db

### DIFF
--- a/app/vector_db.py
+++ b/app/vector_db.py
@@ -16,7 +16,6 @@ _client = None
 _collection = None
 
 
-
 def _get_client() -> PersistentClient:
     """Return a persistent chroma client."""
     global _client


### PR DESCRIPTION
## Summary
- remove extra blank line before `_get_client` in `vector_db.py`

## Testing
- `flake8 app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a278c827c8328ba3da214d97f2730